### PR TITLE
Add HubSpot redirect URL validation

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -1364,12 +1364,16 @@
                           <input [ngClass]="{'error-input': hubspotClientSecretError}" type="text" class="form-control" [(ngModel)]="hubspotClientSecret" [ngModelOptions]="{standalone: true}" (input)="hubspotClientSecretInput()">
                         </div>
                         <div class="form-group">
+                          <label [ngClass]="{'error-label': hubspotRedirectURLError}" class="col-form-label">Redirect URL <span class="text-danger ms-1">*</span></label>
+                          <input [ngClass]="{'error-input': hubspotRedirectURLError}" type="text" class="form-control" [(ngModel)]="hubspotRedirectURL" [ngModelOptions]="{standalone: true}" (input)="hubspotRedirectURLInput()">
+                        </div>
+                        <div class="form-group">
                           <label [ngClass]="{'error-label': hubspotScopeError}" class="col-form-label">Scopes <span class="text-danger ms-1">*</span></label>
                           <ng-select [items]="hubspotScopes" bindLabel="" placeholder="Select Scopes" [(ngModel)]="selectedHubspotScopes" [multiple]="true" (change)="onHubspotScopeChange($event)"></ng-select>
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-secondary" (click)="gotoNewConnections()">Close</button>
-                          <button type="button" class="btn btn-primary" (click)="hubspotSignIn()" [disabled]="(hubspotScopeError || hubspotClientSecretError || displayNameError || hubspotClientIdError) || !(selectedHubspotScopes.length>0 && hubspotClientSecret && hubspotClientId && displayName)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+                          <button type="button" class="btn btn-primary" (click)="hubspotSignIn()" [disabled]="(hubspotScopeError || hubspotClientSecretError || displayNameError || hubspotClientIdError || hubspotRedirectURLError) || !(selectedHubspotScopes.length>0 && hubspotClientSecret && hubspotClientId && displayName && hubspotRedirectURL)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
                         </div>
                       </form>
                     </div>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -114,10 +114,12 @@ export class WorkbenchComponent implements OnInit{
   ninjaRMMScopeError: boolean = false;
   hubspotClientId!: string;
   hubspotClientSecret!: string;
+  hubspotRedirectURL!: string;
   hubspotScopes: string[] = ['crm.objects.contacts.read'];
   selectedHubspotScopes: string[] = [];
   hubspotClientIdError = false;
   hubspotClientSecretError = false;
+  hubspotRedirectURLError = false;
   hubspotScopeError = false;
   openImmybot: boolean = false;
   clientIDImmyBotError: boolean = false;
@@ -1095,9 +1097,13 @@ export class WorkbenchComponent implements OnInit{
       this.hubspotClientIdError = !this.hubspotClientId;
     }
 
-    hubspotClientSecretInput(){
-      this.hubspotClientSecretError = !this.hubspotClientSecret;
-    }
+  hubspotClientSecretInput(){
+    this.hubspotClientSecretError = !this.hubspotClientSecret;
+  }
+
+  hubspotRedirectURLInput(){
+    this.hubspotRedirectURLError = !this.hubspotRedirectURL;
+  }
 
     onHubspotScopeChange(event:any){
       this.selectedHubspotScopes = event;
@@ -2183,6 +2189,8 @@ connectGoogleSheets(){
   this.hubspotClientId = '';
   this.hubspotClientSecret = '';
   this.selectedHubspotScopes = [];
+  this.hubspotRedirectURL = '';
+  this.hubspotRedirectURLError = false;
   }
 
   serverError:boolean = false;


### PR DESCRIPTION
## Summary
- add fields for HubSpot redirect URL validation
- validate redirect URL input and reset errors when closing forms
- mark redirect URL input error in the template
- disable HubSpot Connect button when redirect URL is invalid

## Testing
- `npm run build` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_683f3280d0a48320ab52e78d95027b7f