### PR TITLE
Add cross-db deletion UI

### DIFF
--- a/src/app/components/workbench/database/database.component.html
+++ b/src/app/components/workbench/database/database.component.html
@@ -15,7 +15,10 @@
             </div>
             <div class="mb-0 p-2 br-0 border-bottom">
                 <h6 class="mb-0">Database</h6>
-                <p class="mb-0" [ngbTooltip]="databaseName?.length > 15 ? databaseName : null">{{databaseName?.length > 15 ? (databaseName| slice:0:15)+'...':databaseName}}</p>
+                <p class="mb-0" [ngbTooltip]="databaseName?.length > 15 ? databaseName : null">
+                    {{databaseName?.length > 15 ? (databaseName| slice:0:15)+'...':databaseName}}
+                    <i *ngIf="isCrossDb && crossDbConnections.length > 1" class="ri-delete-bin-7-line ms-1 text-danger cursor-pointer" (click)="openDeleteCrossDbModal(deleteCrossDbModal)"></i>
+                </p>
             </div>
             <!-- <div class="card mb-0 br-0">
             </div> -->
@@ -513,7 +516,9 @@
             </div>
             <div class="p-2 br-0 mb-0 border-bottom d-block ">
                 <h6 class="mb-0">Database</h6>
-                <p class="mb-0">{{databaseName}}</p>
+                <p class="mb-0">{{databaseName}}
+                    <i *ngIf="isCrossDb && crossDbConnections.length > 1" class="ri-delete-bin-7-line ms-1 text-danger cursor-pointer" (click)="openDeleteCrossDbModal(deleteCrossDbModal)"></i>
+                </p>
             </div>
             <div class="card mb-0 mt-1 br-0 customSql-dropdown-menu-h">
                 <div class="sidebar">
@@ -854,6 +859,24 @@
             <button type="button" class="btn ripple btn-secondary" (click)="modal.close('Save click')">
                 Close
             </button>
+        </div>
+    </ng-template>
+
+    <ng-template #deleteCrossDbModal let-modal>
+        <div class="modal-header">
+            <h6 class="modal-title">Delete Connections</h6>
+            <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss('Cross click')"></button>
+        </div>
+        <div class="modal-body p-0">
+            <ul class="list-group list-group-flush">
+                <li *ngFor="let db of crossDbConnections" class="list-group-item d-flex justify-content-between align-items-center">
+                    <span>{{db.display_name}}</span>
+                    <i class="ri-delete-bin-7-line text-danger cursor-pointer" (click)="deleteConnectedDb(db)"></i>
+                </li>
+            </ul>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn ripple btn-secondary" (click)="modal.close('Save click')">Close</button>
         </div>
     </ng-template>
 

--- a/src/app/components/workbench/database/database.component.ts
+++ b/src/app/components/workbench/database/database.component.ts
@@ -161,6 +161,8 @@ export class DatabaseComponent {
   crossDbId= '';
   crossDbFilteredTablesT1: any[] = [];
   originalCrossDbTablesT1: any;
+  crossDbConnections: any[] = [];
+  isCrossDb = false;
   dragTablestoSemanticLayer = false;
   deleteTablesFromSemanticLayer = false;
   canSearchTablesInSemanticLayer = false;
@@ -434,6 +436,8 @@ getSchemaTablesFromConnectedDb(){
   const IdToPass = this.databaseId
   this.schematableList =[];
   this.workbechService.getSchemaTablesFromConnectedDb(IdToPass,obj).subscribe({next: (data) => {
+    this.crossDbConnections = data;
+    this.isCrossDb = data[0]?.is_cross_db;
     if(data[0].cross_db_id){
       this.crossDbId = data[0].cross_db_id;
       console.log(this.crossDbId.length)
@@ -1997,5 +2001,35 @@ clearRelationCondns(){
   this.selectedCndn ='Operator';
   this.selectedClmnT1=null
   this.selectedClmnT2=null;
+}
+
+openDeleteCrossDbModal(modal: any){
+  this.modalService.open(modal, {
+    centered: true,
+    windowClass: 'animate__animated animate__zoomIn',
+  });
+}
+
+deleteConnectedDb(db:any){
+  const obj = {
+    cross_db_id: db.cross_db_id,
+    delete_db_id: db.hierarchy_id
+  };
+  this.workbechService.crossDbDeletion(obj).subscribe({
+    next: () => {
+      this.crossDbConnections = this.crossDbConnections.filter((item: any) => item.hierarchy_id !== db.hierarchy_id);
+      this.isCrossDb = this.crossDbConnections.length > 1;
+      if(this.crossDbConnections.length){
+        this.databaseName = this.crossDbConnections[0].display_name;
+      }
+      if(this.crossDbConnections.length <= 1){
+        this.modalService.dismissAll('close');
+      }
+      this.toasterService.success('Database Deleted Successfully','success',{ positionClass: 'toast-top-right'});
+    },
+    error: () => {
+      this.toasterService.error('Unable to delete database. Please try again.','error',{ positionClass: 'toast-top-right'});
+    }
+  });
 }
 }

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -277,6 +277,12 @@ export class WorkbenchService {
     this.accessToken = JSON.parse( currentUser! )['Token'];
     return this.http.post<any>(`${environment.apiUrl}/database_delete_stmt/`+this.accessToken,obj);
   }
+
+  crossDbDeletion(obj:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/crossdb_deletion/`+this.accessToken,obj);
+  }
   sheetSave(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];


### PR DESCRIPTION
## Summary
- add support for showing delete icon when multiple cross DB connections exist
- implement modal to list and delete cross DB sources
- handle cross DB deletion via new API call

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_683fcc4a58c48320b4988f2bca7189f7