### PR TITLE
Add dashboard copy feature

### DIFF
--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.html
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.html
@@ -82,6 +82,9 @@
                                   [faIconList]="'fa fa-sliders'" [isIcon]="true"></app-insights-button>
                                   <button class="btn btn-icon btn-sm btn-info-light btn-wave waves-effect waves-light" ngbTooltip="Set Schedular" (click)="viewSchedular(dashboard.dashboard_id,autorefresh)"><i class="fa fa-clock" ></i></button>
                                   <button class="btn btn-icon btn-sm btn-orange-light btn-wave waves-effect waves-light" ngbTooltip="Set Alerts" (click)="gotoConfigureEmailAlerts(dashboard.dashboard_id)"><i class="fa fa-bell" ></i></button>
+                                  <button (click)="copyDashboard(dashboard.dashboard_id)" class="btn btn-outline-primary">
+                                    Copy
+                                  </button>
 
                                 </div>
                             </td>
@@ -139,6 +142,9 @@
                             [faIconList]="'fa fa-sliders'" [isIcon]="true"></app-insights-button>
                             <button class="btn btn-icon btn-sm btn-info-light btn-wave waves-effect waves-light me-2" ngbTooltip="Set Schedular" (click)="viewSchedular(dashboard.dashboard_id,autorefresh)"><i class="fa fa-clock" ></i></button>
                             <button class="btn btn-icon btn-sm btn-orange-light btn-wave waves-effect waves-light" ngbTooltip="Set Alerts" (click)="gotoConfigureEmailAlerts(dashboard.dashboard_id)"><i class="fa fa-bell" ></i></button>
+                            <button (click)="copyDashboard(dashboard.dashboard_id)" class="btn btn-outline-primary">
+                              Copy
+                            </button>
 
                           </div>
                   </div>

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
@@ -445,5 +445,20 @@ gotoConfigureEmailAlerts(id:any){
 this.router.navigate(['/analytify/configure-page/email/'+encodedDatabaseId])
 }
 
+copyDashboard(dashboardId:any){
+  const payload = { dashboard_id: [dashboardId] };
+  this.workbechService.copyDashboard(payload).subscribe({
+    next:(data)=>{
+      const newDashboardId = data.dashboard_id;
+      this.loaderService.show();
+      const encodedDashboardId = btoa(newDashboardId.toString());
+      this.router.navigate(['/analytify/home/sheetsdashboard/'+encodedDashboardId]);
+    },
+    error:()=>{
+      this.toasterservice.error('Dashboard copy failed. Please try again.','error',{ positionClass: 'toast-top-right'});
+    }
+  });
+}
+
 
 }

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -455,6 +455,12 @@ export class WorkbenchService {
     this.accessToken = JSON.parse( currentUser! )['Token'];
     return this.http.delete<any>(`${environment.apiUrl}/dashboarddelete/`+dashboardId+'/'+this.accessToken);
   }
+
+  copyDashboard(obj:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/dashboard_copy/`+this.accessToken,obj);
+  }
   getFilteredList(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];


### PR DESCRIPTION
## Summary
- allow users to duplicate dashboards
- add Copy button alongside Scheduler and Set Alerts
- implement copyDashboard action in component
- call new API from service to duplicate dashboard

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68417b4bfa148320994eb56f03383d90