### PR TITLE
Implement multiple datasource switch with copy & switch

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -2158,30 +2158,37 @@
         </div>
       </div>
 
-      <div class="form-group mb-3">
-        <label class="form-label">Current Datasource</label>
-        <select class="form-select" [(ngModel)]="selectedCurrentDb" (change)="onCurrentDbChange()">
-          <option value="" disabled selected>Select Current Database</option>
-          <option *ngFor="let db of currentDbKeys" [value]="db">{{ db }}</option>
-        </select>
-      </div>
-  
-      <div class="form-group mb-3">
-        <label class="form-label">Target Datasource</label>
-        <select  class="form-select" (change)="onTargetDbChange($event)">
-          <option value="" disabled selected>Select Target Database</option>
-          <option *ngFor="let db of targetDbData;  let i = index" [value]="i">{{db.display_name }}</option>
-        </select>
-      </div>
+        <div *ngFor="let cond of switchConditions; let i = index" class="border rounded p-2 mb-2">
+          <div class="row align-items-end">
+            <div class="col">
+              <label class="form-label">Current Datasource</label>
+              <select class="form-select" [(ngModel)]="cond.sourceKey" (change)="onCurrentDbChange(i)">
+                <option value="" disabled>Select Current Database</option>
+                <option *ngFor="let db of getAvailableSources(i)" [value]="db">{{ db }}</option>
+              </select>
+            </div>
+            <div class="col">
+              <label class="form-label">Target Datasource</label>
+              <select  class="form-select" [(ngModel)]="cond.targetHierarchyId" (change)="onTargetDbChange($event,i)">
+                <option value="" disabled>Select Target Database</option>
+                <option *ngFor="let db of cond.targetDbData" [value]="db.hierarchy_id">{{ db.display_name }}</option>
+              </select>
+            </div>
+            <div class="col-auto" *ngIf="switchConditions.length > 1">
+              <button type="button" class="btn btn-link text-danger" (click)="removeCondition(i)"><i class="fa fa-trash"></i></button>
+            </div>
+          </div>
+        </div>
+
+        <div class="text-start mb-2">
+          <button type="button" class="btn btn-outline-primary" (click)="addCondition()" [disabled]="!canAddCondition()">Add New Condition</button>
+        </div>
     </div>
   
     <div class="modal-footer">
-      <button type="button" [disabled]="!selectedCurrentDb || disableAddNew" class="btn btn-info" (click)="addNewDatabaseConnection()">Add New</button>
       <button type="button" class="btn btn-secondary" (click)="modal.dismiss('cancel')">Close</button>
-      <button type="button" [disabled]="!selectedCurrentDb || !targetSelectedDbHierarchyId" class="btn btn-primary" (click)="switchDatabase()" >Switch</button>
-
-
-      
+      <button type="button" class="btn btn-primary" [disabled]="!isConditionsValid()" (click)="switchDatabase(false)">Switch</button>
+      <button type="button" class="btn btn-info" [disabled]="!isConditionsValid()" (click)="switchDatabase(true)">Copy & Switch</button>
     </div>
   </ng-template>
   

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -7998,21 +7998,22 @@ downloadAsPDF() {
   });
 }
 switchDatasourceModalOpen(modal:any){
+  this.switchConditions = [{sourceKey:'', sourceDetails:null, targetDbData:[], targetHierarchyId:''}];
   this.modalService.open(modal, {
     centered: true,size:'lg',
     windowClass: 'animate__animated animate__zoomIn',
   });
-this.getCurrentDbs();
+  this.getCurrentDbs();
 }
 
 currentDbKeys: string[] = [];
-selectedCurrentDb: string = '';
-selectedCurrentDbDetails: any = null;
-targetDbData: any[] = [];  
-sourceDbData: any = {}; 
-currentSelectedDbHierarchyId:any;
-targetSelectedDbHierarchyId:any = '';
-disableAddNew=false;
+sourceDbData: any = {};
+switchConditions: any[] = [{
+  sourceKey: '',
+  sourceDetails: null,
+  targetDbData: [],
+  targetHierarchyId: ''
+}];
 fileData:any;
 getCurrentDbs(){
   const obj ={
@@ -8039,86 +8040,104 @@ getCurrentDbs(){
     }
   })
 }
-loadTargetDbs(){
+loadTargetDbs(index:number){
+  const cond = this.switchConditions[index];
   const obj ={
     dashboard_id:this.dashboardId,
-    server_type:this.selectedCurrentDbDetails.server_type
+    server_type:cond.sourceDetails.server_type
   }
-     this.workbechService.getTargetdbsForSwitch(obj).subscribe({
-        next:(data)=>{
-          const currentHierarchyId = this.selectedCurrentDbDetails.hierarchy_id;
-          this.targetDbData = data.user_connections.filter(
-            (db: any) => db.hierarchy_id !== currentHierarchyId
-          );
-          console.log('Filtered Target DBs:', this.targetDbData);
-        },
-        error:(error)=>{
-          console.log(error);
-          this.toasterService.error(error.error.message, 'error', { positionClass: 'toast-top-right' })
-        }
-      })
-}
-onCurrentDbChange() {
-  const selectedList = this.sourceDbData[this.selectedCurrentDb];
-  this.selectedCurrentDbDetails = selectedList ? selectedList[0] : null;
-  if(this.selectedCurrentDbDetails){
-    this.currentSelectedDbHierarchyId = this.selectedCurrentDbDetails.hierarchy_id;
-    const restrictedTypes = ['GOOGLE_SHEETS', 'GOOGLE_ANALYTICS', 'SALESFORCE', 'QUICKBOOKS','CROSS_DATABASE'];
-    this.disableAddNew = restrictedTypes.includes(this.selectedCurrentDbDetails.server_type);
+  this.workbechService.getTargetdbsForSwitch(obj).subscribe({
+      next:(data)=>{
+        const currentHierarchyId = cond.sourceDetails.hierarchy_id;
+        cond.targetDbData = data.user_connections.filter(
+          (db: any) => db.hierarchy_id !== currentHierarchyId
+        );
+      },
+      error:(error)=>{
+        console.log(error);
+        this.toasterService.error(error.error.message, 'error', { positionClass: 'toast-top-right' })
       }
-  this.loadTargetDbs();
+    })
 }
-onTargetDbChange(event: Event){
-  const selectedIndex = (event.target as HTMLSelectElement).value;
-  const selectedDatabase = this.targetDbData[+selectedIndex];
-  console.log('Selected Object:', selectedDatabase);
-  this.targetSelectedDbHierarchyId = selectedDatabase.hierarchy_id;
+onCurrentDbChange(index:number) {
+  const cond = this.switchConditions[index];
+  const selectedList = this.sourceDbData[cond.sourceKey];
+  cond.sourceDetails = selectedList ? selectedList[0] : null;
+  cond.targetHierarchyId = '';
+  cond.targetDbData = [];
+  if(cond.sourceDetails){
+    this.loadTargetDbs(index);
+  }
 }
-switchDatabase() {
+onTargetDbChange(event: Event,index:number){
+  const selectedId = (event.target as HTMLSelectElement).value;
+  this.switchConditions[index].targetHierarchyId = selectedId;
+}
+switchDatabase(isDuplicate: boolean = false) {
+  const existingIds = this.switchConditions.map(c => c.sourceDetails?.hierarchy_id).filter(id => id);
+  const targetIds = this.switchConditions.map(c => c.targetHierarchyId).filter(id => id);
   const obj ={
-    existing_h_id:this.currentSelectedDbHierarchyId,
-    switch_h_id:this.targetSelectedDbHierarchyId,
-    dashboard_id:this.dashboardId
+    existing_h_id:existingIds,
+    switch_h_id:targetIds,
+    dashboard_id:this.dashboardId,
+    is_duplicate:isDuplicate ? 'true' : 'false'
   }
   this.workbechService.datbaseSwitch(obj).subscribe({
     next:(data)=>{
       console.log(data);
       if(data.message ==='Datasource switched successfully'){
+        if(isDuplicate){
+          this.dashboardId = data.dashboard_id;
+        }
         this.refreshDashboard(true);
         Swal.fire({
           icon: 'success',
           title: data.message,
           text: 'Data updated with new datasource',
           width: '400px',
-        })
+        }).then(()=>{
+          if(isDuplicate){
+            const encodedId = btoa(data.dashboard_id.toString());
+            this.router.navigate(['/analytify/home/sheetsdashboard/' + encodedId]);
+          }
+        });
       }
       this.modalService.dismissAll();
-      this.currentSelectedDbHierarchyId='';
-      this.targetSelectedDbHierarchyId=null;
-      this.selectedCurrentDb = '';  
     },
     error:(error)=>{
       console.log(error);
       this.toasterService.error(error.error.message, 'error', { positionClass: 'toast-top-right' })
-      // Swal.fire({
-      //   icon: 'error',
-      //   title: 'oops!',
-      //   text: error.error.message,
-      //   width: '400px',
-      // })
     }
   })
 }
+getAvailableSources(index:number){
+  const selected = this.switchConditions.filter((_,i)=>i!==index).map(c=>c.sourceKey).filter(k=>k);
+  return this.currentDbKeys.filter(key => !selected.includes(key));
+}
+addCondition(){
+  this.switchConditions.push({sourceKey:'', sourceDetails:null, targetDbData:[], targetHierarchyId:''});
+}
+removeCondition(index:number){
+  this.switchConditions.splice(index,1);
+}
+canAddCondition(){
+  return this.switchConditions.length < this.currentDbKeys.length;
+}
+isConditionsValid(){
+  return this.switchConditions.every(c => c.sourceKey && c.targetHierarchyId);
+}
 addNewDatabaseConnection(){
-  if(this.selectedCurrentDbDetails.server_type === 'EXCEL'){
+  const details = this.switchConditions[0].sourceDetails;
+  if(!details) return;
+  if(details.server_type === 'EXCEL'){
       this.fileInput1.nativeElement.click();
-  }else if(this.selectedCurrentDbDetails.server_type === 'CSV'){
+  }else if(details.server_type === 'CSV'){
         this.fileInput.nativeElement.click();
   }else{
-  this.modalService.dismissAll('close');
-  const encodedSourceDbId = btoa(this.currentSelectedDbHierarchyId.toString());
-  const encodedDashboardId = btoa(this.dashboardId.toString());
-  this.router.navigate(['analytify/datasources/datasource-switch/'+this.selectedCurrentDbDetails.server_type+'/'+encodedSourceDbId+'/'+encodedDashboardId])
+    this.modalService.dismissAll('close');
+    const encodedSourceDbId = btoa(details.hierarchy_id.toString());
+    const encodedDashboardId = btoa(this.dashboardId.toString());
+    this.router.navigate(['analytify/datasources/datasource-switch/'+details.server_type+'/'+encodedSourceDbId+'/'+encodedDashboardId])
   }
 }
 uploadfileCsv(event:any){
@@ -8138,7 +8157,7 @@ csvUpload(fileInput: any){
       console.log(responce)
           if(responce){
             this.toasterService.success('Connected','success',{ positionClass: 'toast-top-right'});
-            this.targetSelectedDbHierarchyId = responce.hierarchy_id
+            this.switchConditions[0].targetHierarchyId = responce.hierarchy_id;
             this.switchDatabase();
           }
         },
@@ -8171,7 +8190,7 @@ excelUpload(fileInput: any){
     this.workbechService.DbConnectionFiles(formData).subscribe({next: (responce) => {
       console.log(responce)
           if(responce){
-            this.targetSelectedDbHierarchyId = responce.hierarchy_id;
+            this.switchConditions[0].targetHierarchyId = responce.hierarchy_id;
             this.switchDatabase();
           }
         },


### PR DESCRIPTION
## Summary
- support multiple datasource switch rows with dynamic options
- add Copy & Switch option and API payload updates
- clean up datasource switching logic with helper methods

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6847f347b7b0832080e6041b0fe1137a