### PR TITLE
Fix router state on datasource switch

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -283,7 +283,7 @@ export class SheetsdashboardComponent implements OnDestroy {
         }
 
         const navigation = this.router.getCurrentNavigation();
-        const dbSwitched = navigation?.extras?.state?.['dbSwitched'];
+        const dbSwitched = navigation?.extras?.state?.['dbSwitched'] ?? history.state?.['dbSwitched'];
       
         if (dbSwitched) {
           this.getSavedDashboardData();
@@ -600,6 +600,19 @@ export class SheetsdashboardComponent implements OnDestroy {
       .pipe(takeUntil(this.destroy$))
       .subscribe(() => {
         this.getSavedDashboardDataPublic();
+      });
+
+    this.route.paramMap
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => {
+        const navigation = this.router.getCurrentNavigation();
+        const dbSwitched = navigation?.extras?.state?.['dbSwitched'] ?? history.state?.['dbSwitched'];
+        if (dbSwitched) {
+          this.getSavedDashboardData();
+          setTimeout(() => {
+            this.refreshDashboard(true);
+          }, 1000);
+        }
       });
 
   }


### PR DESCRIPTION
## Summary
- persist datasource switch state when navigating to same component
- refresh the dashboard when route params change

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6848219537bc8320836339a6dcaca32b