### PR TITLE
Handle dynamic column fetching for integrations

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -258,6 +258,12 @@ export class WorkbenchService {
     this.accessToken = JSON.parse( currentUser! )['Token'];
     return this.http.post<any>(`${environment.apiUrl}/tables_test_joining/`+this.accessToken,obj);
   }
+
+  dataDumping(obj:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/data_dumping/`+this.accessToken,obj);
+  }
   getTableJoiningData(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];


### PR DESCRIPTION
## Summary
- add API call for `/data_dumping/` in workbench service
- fetch table columns on-demand in database component when columns are empty

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_684b1a2f8d048320aa6976a57277b596