### PR TITLE
Fix target sheet filtering in drill-through actions

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -6450,21 +6450,27 @@ formatNumber(value: number,decimalPlaces:number,displayUnits:string,prefix:strin
   //   })).filter(sheet => sheet.id != this.sourceSheetId);
   //   console.log('source:',this.sourceSheetList, 'target: ',this.targetSheetList);
   // }
-  getTargetSheetsList(event? : any) {
+  getTargetSheetsList(event?: any) {
     this.targetSheetList = [];
     this.isAllTargetSheetsSelected = false;
-    const sourceCategory = Object.keys(this.sourceSheetList);
-    Object.keys(this.sourceSheetList).forEach((category: any) => {
-      this.targetSheetList.push(
-        ...this.sourceSheetList[category]
-          .filter((sheet: any) => sheet.sheet_id !== this.sourceSheetId && sheet.chart_id !== 25)
-          .map((sheet: any) => ({
-            ...sheet,
-            selected: false,
-          }))
-      );
-    });
-    console.log("Target Sheets:", this.targetSheetList);
+
+    const selectedId = Number(this.sourceSheetId);
+
+    // Determine which category (tab) the selected source sheet belongs to
+    const sourceCategory = Object.keys(this.sourceSheetList).find((category: any) =>
+      this.sourceSheetList[category].some((sheet: any) => Number(sheet.sheet_id) === selectedId)
+    );
+
+    if (sourceCategory) {
+      this.targetSheetList = this.sourceSheetList[sourceCategory]
+        .filter((sheet: any) => Number(sheet.sheet_id) !== selectedId && sheet.chart_id !== 25)
+        .map((sheet: any) => ({
+          ...sheet,
+          selected: false,
+        }));
+    }
+
+    console.log('Target Sheets:', this.targetSheetList);
   }
   
   updateSelectedSheets() {


### PR DESCRIPTION
## Summary
- ensure target sheet list uses only the tab of the selected source sheet

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6851359fd258832093fa05046b4f8906