### PR TITLE
Refactor axis saving model

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -22,8 +22,9 @@ interface Dimension {
   styleUrl: './insight-apex.component.scss'
 })
 export class InsightApexComponent {
-  @Input() chartsRowData: any; 
+  @Input() chartsRowData: any;
   @Input() chartsColumnData: any;
+  @Input() axisConfig: any;
   @Input() dualAxisColumnData : any;
   @Input() dualAxisRowData : any;
   @Input() chartType : any;
@@ -100,6 +101,15 @@ export class InsightApexComponent {
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if(changes['axisConfig'] && this.axisConfig){
+      if(this.axisConfig.type === 'dual'){
+        this.dualAxisColumnData = this.axisConfig.xAxis;
+        this.dualAxisRowData = this.axisConfig.yAxis;
+      } else {
+        this.chartsColumnData = this.axisConfig.xAxis;
+        this.chartsRowData = this.axisConfig.yAxis;
+      }
+    }
 
     if(changes['SDKChartOptions']){
       this.chartOptions = this.SDKChartOptions;

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -27,7 +27,8 @@ interface Dimension {
   styleUrl: './insight-echart.component.scss'
 })
 export class InsightEchartComponent {
-  @Input() chartsRowData: any; 
+  @Input() chartsRowData: any;
+  @Input() axisConfig: any;
   @Input() isZoom: any;
   @Input() chartsColumnData: any;
   @Input() chartType!:string;
@@ -1907,6 +1908,16 @@ chartInitialize(){
     }
   }
   ngOnChanges(changes: SimpleChanges) {
+    if(changes['axisConfig'] && this.axisConfig){
+      if(this.axisConfig.type === 'dual'){
+        this.dualAxisColumnData = this.axisConfig.xAxis;
+        this.dualAxisRowData = this.axisConfig.yAxis;
+      } else {
+        this.chartsColumnData = this.axisConfig.xAxis;
+        this.chartsRowData = this.axisConfig.yAxis;
+      }
+      this.resetchartoptions();
+    }
     
      if(changes['SDKChartOptions']){
       if(this.chartType === 'map'){

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -2437,50 +2437,11 @@ const obj={
     "items_per_page":this.itemsPerPage,
     "total_items":this.totalItems,
 
-    "barYaxis":this.saveBar,
-    "barXaxis":this.barXaxis,
-  //  "barOptions":this.barOptions,
-
-    "pieYaxis":this.savePie,
-    "pieXaxis":this.pieXaxis,
-  //   "pieOptions":this.pieOptions,
-
-    "lineYaxis":this.lineYaxis,
-    "lineXaxis": this.lineXaxis,
-  //   "lineOptions":this.lineOptions,
-
-    "areaYaxis":this.areaYaxis,
-    "areaXaxis":this.areaXaxis,
-  //   "areaOptions":this.areaOptions,
-
-      "sidebysideBarYaxis": this.sidebysideBarYaxis,
-      "sidebysideBarXaxis": this.sidebysideBarXaxis,
-  //     "sidebysideBarOptions":this.sidebysideBarOptions,
-   
-      "stokedBarYaxis": this.stokedBarYaxis,
-      "stokedBarXaxis": this.stokedBarXaxis,
-  //     "stokedOptions":this.stokedOptions,
-  
-      "barLineYaxis":this.barLineYaxis,
-      "barLineXaxis":this.barLineXaxis,
-  //     "barLineOptions":this.barLineOptions,
-
-      "hStockedYaxis": this.hStockedYaxis,
-      "hStockedXaxis": this.hStockedXaxis,
-  //     "hStockedOptions":this.hStockedOptions,
-
-      "hgroupedYaxis": this.hgroupedYaxis,
-      "hgroupedXaxis": this.hgroupedXaxis,
-  //     "hgroupedOptions":this.hgroupedOptions,
-
-      "multiLineYaxis":this.multiLineYaxis,
-      "multiLineXaxis": this.multiLineXaxis,
-  //     "multiLineOptions":this.multiLineOptions,
-
-      "donutYaxis": this.donutYaxis,
-      "donutXaxis": this.donutXaxis,
-      "decimalplaces": this.donutDecimalPlaces,
-  //     "donutOptions":this.donutOptions,
+    "axisConfig": {
+      xAxis: [7,5,4,2,3,8,27,29].includes(this.chartId) ? this.dualAxisColumnData : this.chartsColumnData,
+      yAxis: [7,5,4,2,3,8,27,29].includes(this.chartId) ? this.dualAxisRowData : this.chartsRowData,
+      type: [7,5,4,2,3,8,27,29].includes(this.chartId) ? 'dual' : 'single'
+    },
 
       "kpiData": kpiData,
       "kpiFontSize": kpiFontSize,

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -2081,78 +2081,53 @@ export class SheetsdashboardComponent implements OnDestroy {
     });
   }
   getChartOptionsBasedOnType(sheet:any){
-    if(sheet.chart_id === 9){
-      let xaxis = sheet.sheet_data?.results?.barXaxis;
-      let yaxis = sheet.sheet_data?.results?.barYaxis;
+    const axisConfig = sheet.sheet_data?.results?.axisConfig;
+    const xaxis = axisConfig?.xAxis;
+    const yaxis = axisConfig?.yAxis;
+    if(sheet.chart_id === 9 || sheet.chart_id === 6){
       let savedOptions = sheet.sheet_data.savedChartOptions;
-      return this.barChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart) 
-    }
-    if(sheet.chart_id === 6){
-      let xaxis = sheet.sheet_data?.results?.barXaxis;
-      let yaxis = sheet.sheet_data?.results?.barYaxis;
-      let savedOptions = sheet.sheet_data.savedChartOptions;
-      return this.barChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart) 
+      return this.barChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     if(sheet.chart_id === 29){
-      let xaxis = sheet.sheet_data?.results?.mapChartXaxis;
-      let yaxis = sheet.sheet_data?.results?.mapChartYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
-      return sheet.sheet_data.savedChartOptions;
-      // return this.mapChartOptions(xaxis,yaxis,savedOptions) 
+      return savedOptions;
     }
     if(sheet.chart_id === 17){
-      let xaxis = sheet.sheet_data?.results?.areaXaxis;
-      let yaxis = sheet.sheet_data?.results?.areaYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
       return this.areaChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     if(sheet.chart_id === 13){
-      let xaxis = sheet.sheet_data?.results?.lineXaxis;
-      let yaxis = sheet.sheet_data?.results?.lineYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
       return this.lineChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     if(sheet.chart_id === 24){
-      let xaxis = sheet.sheet_data?.results?.pieXaxis;
-      let yaxis = sheet.sheet_data?.results?.pieYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
       return this.pieChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     //sidebyside
     if(sheet.chart_id === 7){
-      let xaxis = sheet.sheet_data?.results?.sidebysideBarXaxis;
-      let yaxis = sheet.sheet_data?.results?.sidebysideBarYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
-
-      const dimensions: Dimension[] =xaxis
-      const categories = this.flattenDimensions(dimensions)
-      return this.sidebySideBarChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart)
+      const dimensions: Dimension[] = xaxis;
+      const categories = this.flattenDimensions(dimensions);
+      return this.sidebySideBarChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart);
 
     }
     if(sheet.chart_id === 12){//radar
       return sheet.sheet_data.savedChartOptions;
-      let xaxis = sheet.sheet_data?.results?.sidebysideBarXaxis;
-      let yaxis = sheet.sheet_data?.results?.sidebysideBarYaxis;
+      const dimensions: Dimension[] = xaxis;
+      const categories = this.flattenDimensions(dimensions);
       let savedOptions = sheet.sheet_data.savedChartOptions;
-
-      const dimensions: Dimension[] =xaxis
-      const categories = this.flattenDimensions(dimensions)
       return this.sidebySideBarChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart)
 
     }
     if(sheet.chart_id === 5){
-      let xaxis = sheet.sheet_data?.results?.stokedBarXaxis;
-      let yaxis = sheet.sheet_data?.results?.stokedBarYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
-
       const dimensions: Dimension[] = xaxis;
       const categories = this.flattenDimensions(dimensions);
 
       return this.stockedBarChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     if(sheet.chart_id === 4){
-      let xaxis = sheet.sheet_data?.results?.barLineXaxis;
-      let yaxis = sheet.sheet_data?.results?.barLineYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
       console.log('barlinexaxis',xaxis)
       const dimensions: Dimension[] = xaxis;
@@ -2162,8 +2137,6 @@ export class SheetsdashboardComponent implements OnDestroy {
       return this.barLineChartOptions(categories,yaxis,savedOptions)
     }
     if(sheet.chart_id === 2){
-      let xaxis = sheet.sheet_data?.results?.hStockedXaxis;
-      let yaxis = sheet.sheet_data?.results?.hStockedYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
 
       const dimensions: Dimension[] = xaxis;
@@ -2171,8 +2144,6 @@ export class SheetsdashboardComponent implements OnDestroy {
       return this.hStockedBarChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart);
     }
     if(sheet.chart_id === 3){
-      let xaxis = sheet.sheet_data?.results?.hgroupedXaxis;
-      let yaxis = sheet.sheet_data?.results?.hgroupedYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
 
       const dimensions: Dimension[] = xaxis;
@@ -2181,18 +2152,13 @@ export class SheetsdashboardComponent implements OnDestroy {
       return this.hGroupedChartOptions(categories,yaxis,savedOptions,sheet.sheet_data.isEChart)
     }
     if(sheet.chart_id === 8){
-      let xaxis = sheet.sheet_data?.results?.multiLineXaxis;
-      let yaxis = sheet.sheet_data?.results?.multiLineYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
-
       const dimensions: Dimension[] = xaxis;
       const categories = this.flattenDimensions(dimensions);
 
       return this.multiLineChartOptions(categories,yaxis,savedOptions)
     }
     if(sheet.chart_id === 10){
-      let xaxis = sheet.sheet_data?.results?.donutXaxis;
-      let yaxis = sheet.sheet_data?.results?.donutYaxis;
       let savedOptions = sheet.sheet_data.savedChartOptions;
       this.donutDecimalPlaces = sheet.sheet_data?.results?.decimalplaces;
       return this.donutChartOptions(xaxis,yaxis,savedOptions,sheet.sheet_data.isEChart)

--- a/src/app/models/chart-save-model.ts
+++ b/src/app/models/chart-save-model.ts
@@ -1,0 +1,10 @@
+export interface AxisConfig {
+  xAxis: any;
+  yAxis: any;
+  type: 'single' | 'dual';
+}
+
+export interface ChartSaveModel {
+  axisConfig: AxisConfig;
+  savedChartOptions: any;
+}

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -6,6 +6,7 @@ import { WorkbenchService } from '../components/workbench/workbench.service';
 import { uuidv4 } from '@firebase/util';
 import { ToastrService } from 'ngx-toastr';
 import _ from 'lodash';
+import { ChartSaveModel } from '../models/chart-save-model';
 
 interface TableRow {
   [key: string]: any;
@@ -583,68 +584,24 @@ export class TemplateDashboardService {
         // "col": tablePreviewCol,
         // "row": tablePreviewRow,
         "results": {
-          // "tableData": this.saveTableData,
-          // "tableColumns": this.savedisplayedColumns,
-          // "banding": this.banding,
-          // "color1": bandColor1,
-          // "color2": bandColor2,
-          // "items_per_page": this.itemsPerPage,
-          // "total_items": this.totalItems,
-
-          "barYaxis": chartsRowData,
-          "barXaxis": chartsColumnData,
-          //  "barOptions":this.barOptions,
-
-          "pieYaxis": chartsRowData,
-          "pieXaxis": chartsColumnData,
-          //   "pieOptions":this.pieOptions,
-
-          "lineYaxis": chartsRowData,
-          "lineXaxis": chartsColumnData,
-          //   "lineOptions":this.lineOptions,
-
-          "areaYaxis": chartsRowData,
-          "areaXaxis": chartsColumnData,
-          //   "areaOptions":this.areaOptions,
-
-          "sidebysideBarYaxis": dualAxisRowData,
-          "sidebysideBarXaxis": dualAxisColumnData,
-          //     "sidebysideBarOptions":this.sidebysideBarOptions,
-
-          "stokedBarYaxis": dualAxisRowData,
-          "stokedBarXaxis": dualAxisColumnData,
-          //     "stokedOptions":this.stokedOptions,
-
-          "barLineYaxis": dualAxisRowData,
-          "barLineXaxis": dualAxisColumnData,
-          //     "barLineOptions":this.barLineOptions,
-
-          "hStockedYaxis": dualAxisRowData,
-          "hStockedXaxis": dualAxisColumnData,
-          //     "hStockedOptions":this.hStockedOptions,
-
-          "hgroupedYaxis": dualAxisRowData,
-          "hgroupedXaxis": dualAxisColumnData,
-          //     "hgroupedOptions":this.hgroupedOptions,
-
-          "multiLineYaxis": dualAxisRowData,
-          "multiLineXaxis": dualAxisColumnData,
-          //     "multiLineOptions":this.multiLineOptions,
-
-          "donutYaxis": chartsRowData,
-          "donutXaxis": chartsColumnData,
-          // "decimalplaces": this.donutDecimalPlaces,
-          //     "donutOptions":this.donutOptions,
-
+          // legacy table and styling options omitted for brevity
+          "axisConfig": {
+            xAxis: data.chart_id == 7 || data.chart_id == 5 || data.chart_id == 4 || data.chart_id == 2 || data.chart_id == 3 || data.chart_id == 8 || data.chart_id == 27 || data.chart_id == 29
+              ? dualAxisColumnData
+              : chartsColumnData,
+            yAxis: data.chart_id == 7 || data.chart_id == 5 || data.chart_id == 4 || data.chart_id == 2 || data.chart_id == 3 || data.chart_id == 8 || data.chart_id == 27 || data.chart_id == 29
+              ? dualAxisRowData
+              : chartsRowData,
+            type: data.chart_id == 7 || data.chart_id == 5 || data.chart_id == 4 || data.chart_id == 2 || data.chart_id == 3 || data.chart_id == 8 || data.chart_id == 27 || data.chart_id == 29
+              ? 'dual'
+              : 'single'
+          },
           "kpiData": tranformedData.rows_data,
           "kpiFontSize": 16,
-          // "kpicolor": kpiColor,
           "kpiNumber": tranformedData.rows_data[0]?.result_data[0],
           "kpiPrefix": "",
           "kpiSuffix": "",
           kpiDecimalUnit: "none"
-          // "kpiDecimalUnit": this.KPIDisplayUnits,
-          // "kpiDecimalPlaces": this.KPIDecimalPlaces
         },
         "isApexChart": false,
         "isEChart": true,


### PR DESCRIPTION
## Summary
- introduce `ChartSaveModel` interface for storing axis config
- update sheet save/update logic to use unified `axisConfig`
- adjust dashboard retrieval to read from new model
- add `axisConfig` input handling to insight chart components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68528d2434908320af54ff318477b5ec