### PR TITLE
Add Tally integration

### DIFF
--- a/src/app/components/workbench/landingpage/landingpage.component.html
+++ b/src/app/components/workbench/landingpage/landingpage.component.html
@@ -575,6 +575,10 @@
                                         <img alt="product" src="./assets/images/icons/Halopsa-icon.png"
                                             class="w-5 h-5 border me-2">{{database.server_type | lowercase}}
                                     </td>
+                                    <td *ngIf="database.server_type === 'TALLY'">
+                                        <img alt="product" src="./assets/images/icons/Halopsa-icon.png"
+                                            class="w-5 h-5 border me-2">{{database.server_type | lowercase}}
+                                    </td>
                                     <td *ngIf="database.server_type === 'IMMYBOT'">
                                         <img alt="product" src="./assets/images/icons/immybot.png"
                                             class="w-5 h-5 border me-2">{{database.server_type | lowercase}}

--- a/src/app/components/workbench/transformation-list/transformation-list.component.html
+++ b/src/app/components/workbench/transformation-list/transformation-list.component.html
@@ -107,6 +107,10 @@
                                     <img alt="product" src="./assets/images/icons/Halopsa-icon.png"
                                         class="w-5 h-5 border me-2">{{transformation.server_type}}
                                 </td>
+                                <td *ngIf="transformation.server_type === 'TALLY'">
+                                    <img alt="product" src="./assets/images/icons/Halopsa-icon.png"
+                                        class="w-5 h-5 border me-2">{{transformation.server_type}}
+                                </td>
                                 <td *ngIf="transformation.server_type === 'SHOPIFY'">
                                     <img alt="product" src="./assets/images/icons/shopify-large-1.jpg"
                                         class="w-5 h-5 border me-2">{{transformation.server_type}}
@@ -189,6 +193,10 @@
                                     <span *ngIf="transformation.server_type === 'HALOPS'"
                                         class="avatar rounded-circle">
                                         <img src="./assets/images/icons/Halopsa-icon.png" alt="HALOPS"
+                                            class="rounded-circle"></span>
+                                    <span *ngIf="transformation.server_type === 'TALLY'"
+                                        class="avatar rounded-circle">
+                                        <img src="./assets/images/icons/Halopsa-icon.png" alt="TALLY"
                                             class="rounded-circle"></span>
                                     <span *ngIf="transformation.server_type === 'SHOPIFY'"
                                         class="avatar rounded-circle">

--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -146,7 +146,18 @@
                     <div class="mb-2">
                       <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1" >*</span></label>
                             <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. InsignApps" (input)="displayNameIntegrationConditionError()">
-                        </div>
+                </div>
+              </form>
+            } @else if(databaseType == 'tally') {
+              <form>
+                <div class="mb-2">
+                  <label [ngClass]="{'error-label': tallyTokenError}" class="col-form-label">Token Key <span class="text-danger ms-1">*</span></label>
+                  <input [ngClass]="{'error-input': tallyTokenError}" type="text" class="form-control" [(ngModel)]="tallyToken" [ngModelOptions]="{standalone: true}" (input)="tallyTokenInputError()">
+                </div>
+                <div class="mb-2">
+                  <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1" >*</span></label>
+                  <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. Tally" (input)="displayNameIntegrationConditionError()">
+                </div>
               </form>
             }@else if(databaseType == 'google_analytics') {
               <form>
@@ -248,12 +259,14 @@
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="modal.close('cross click')">Close</button>
               <button type="button" class="btn btn-primary" (click)="ninjaRMMUpdate()"  [disabled]="(ninjaRMMScopeError || ninjaRMMClientSecretError || displayNameError || ninjaRMMClientIdError) || !(selectedNinjaRMMScopes.length > 0 && ninjaRMMClientSecret && ninjaRMMClientid && displayName) ">Update</button>
       
-            }
+            } 
              @else if(databaseType == 'shopify') {
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="modal.close('cross click')">Close</button>
               <button type="button" class="btn btn-primary" (click)="shopifyConnectionUpdate()" [disabled]="(shopifyApiTokenError || shopifyNameError || displayNameError) || !(shopifyToken && shopifyName && displayName)">Update</button>
-            }
-            @else if(databaseType == 'google_analytics') {
+            } @else if(databaseType == 'tally') {
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="modal.close('cross click')">Close</button>
+              <button type="button" class="btn btn-primary" (click)="tallyUpdate()" [disabled]="(tallyTokenError || displayNameError) || !(tallyToken && displayName)">Update</button>
+            } @else if(databaseType == 'google_analytics') {
               <button type="button" class="btn btn-secondary" (click)="modal.close('cross click')">Close</button>
               <button type="button" class="btn btn-primary"
                       (click)="googleAnalyticsUpdate()"
@@ -376,6 +389,9 @@
                       <td *ngIf="database.server_type === 'HALOPS'">
                         <img alt="product" src="./assets/images/icons/Halopsa-icon.png" class="w-5 h-5 border me-2">{{database.server_type}}
                       </td>
+                      <td *ngIf="database.server_type === 'TALLY'">
+                        <img alt="product" src="./assets/images/icons/Halopsa-icon.png" class="w-5 h-5 border me-2">{{database.server_type}}
+                      </td>
                       <td *ngIf="database.server_type === 'IMMYBOT'">
                         <img alt="product" src="./assets/images/icons/immybot.png" class="w-5 h-5 border me-2">{{database.server_type}}
                       </td>
@@ -482,8 +498,10 @@
                                               <img src="./assets/images/icons/connectwise-icon.png" alt="" class="rounded-circle"></span>
                                               <span *ngIf="database.server_type === 'HALOPS'" class="avatar avatar rounded-circle">
                                                 <img src="./assets/images/icons/Halopsa-icon.png" alt="" class="rounded-circle"></span>
-                                                <span *ngIf="database.server_type === 'IMMYBOT'" class="avatar avatar rounded-circle">
-                                                  <img src="./assets/images/icons/immybot.png" alt="" class="rounded-circle"></span>
+                                              <span *ngIf="database.server_type === 'TALLY'" class="avatar avatar rounded-circle">
+                                                <img src="./assets/images/icons/Halopsa-icon.png" alt="" class="rounded-circle"></span>
+                                              <span *ngIf="database.server_type === 'IMMYBOT'" class="avatar avatar rounded-circle">
+                                                <img src="./assets/images/icons/immybot.png" alt="" class="rounded-circle"></span>
                                                 <span *ngIf="database.server_type === 'SHOPIFY'" class="avatar avatar rounded-circle">
                                                   <img src="./assets/images/icons/shopify-large-1.jpg" alt="" class="rounded-circle"></span>
                                                   <span *ngIf="database.server_type === 'GOOGLE_SHEETS'" class="avatar avatar rounded-circle">
@@ -1194,6 +1212,35 @@
                         <li><span class="mb-0"><strong>Display Name:</strong>
                           The Display Name is a user-friendly name for your store that will be shown on our platform.</span></li>
                     </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          }
+          @if(openTallyForm){
+          <div class="main-container container-fluid px-4 TopHeader">
+            <div class="row">
+              <div class="col-md-12 col-xl-6 p-1 mb-0">
+                <div class="card Relational-database-height">
+                  <div class="card-header">
+                    <h4 class="card-title">Connect To Tally</h4>
+                  </div>
+                  <div class="card-body">
+                    <form>
+                      <div class="form-group">
+                        <label [ngClass]="{'error-label': tallyTokenError}" class="col-form-label">Token Key <span class="text-danger ms-1">*</span></label>
+                        <input [ngClass]="{'error-input': tallyTokenError}" type="text" class="form-control" [(ngModel)]="tallyToken" [ngModelOptions]="{standalone: true}" (input)="tallyTokenInputError()">
+                      </div>
+                      <div class="form-group">
+                        <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1" >*</span></label>
+                        <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. Tally" (input)="displayNameIntegrationConditionError()">
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" (click)="datasourceSwitchUI ? gotoDashboardWithoutSwitch() : gotoNewConnections()">Close</button>
+                        <button type="button" class="btn btn-primary" (click)="tallySignIn()" [disabled]="(tallyTokenError || displayNameError) || !(tallyToken && displayName)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+                      </div>
+                    </form>
                   </div>
                 </div>
               </div>
@@ -2108,18 +2155,26 @@
                           <img src="/assets/images/Db_server_images/shopify-small-1.jpg"alt="Image" class="card-img">
                         </div>
                         <div class="logo-txt mt-2 text-center fw-600">
-                          <span>Shopify</span>
-                        </div>
-                      </div>
-                      <div class="database-logo">
+          <span>Shopify</span>
+        </div>
+      </div>
+      <div class="database-logo">
+        <div class="imgcard p-4" (click)="connectTally()">
+          <img src="/assets/images/Db_server_images/Halopsa-big.png" alt="Image" class="card-img"> <!-- placeholder icon -->
+        </div>
+        <div class="logo-txt mt-2 text-center fw-600">
+          <span>Tally</span>
+        </div>
+      </div>
+      <div class="database-logo">
                         <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}"  (click)="!iscrossDbSelect && connectGoogleSheets()">
                           <img src="/assets/images/Db_server_images/googlesheets-icon.png"alt="Image" class="card-img">
                         </div>
                         <div class="logo-txt mt-2 text-center fw-600">
                           <span>Google Sheets</span>
                         </div>
-                      </div>    
-                      <div class="database-logo">
+      </div>
+      <div class="database-logo">
                         <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}"  (click)="!iscrossDbSelect && connectNinjaRMM()">
                           <img src="/assets/images/Db_server_images/ninjaRMM.png"alt="Image" class="card-img">
                         </div>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -28,6 +28,7 @@ import _ from 'lodash';
 
 import { TemplateDashboardService } from '../../../services/template-dashboard.service';
 import { NgSelectModule } from '@ng-select/ng-select';
+import { TallyIntegrationService } from '../../../services/tally-integration.service';
 
 
 @Component({
@@ -62,6 +63,7 @@ export class WorkbenchComponent implements OnInit{
   openMicrosoftSqlServerForm = false;
   openSnowflakeServerForm = false;
   openMongoDbForm = false;
+  openTallyForm = false;
   sqlLiteForm = false;
   openTablesUI = false;
   ibmDb2Form = false;
@@ -122,7 +124,7 @@ export class WorkbenchComponent implements OnInit{
   subDomainError: boolean = false;
 
   constructor(private modalService: NgbModal, private workbechService:WorkbenchService,private router:Router,private toasterservice:ToastrService,private route:ActivatedRoute,
-    private viewTemplateService:ViewTemplateDrivenService,@Inject(DOCUMENT) private document: Document,private loaderService:LoaderService,private cd:ChangeDetectorRef,private templateDashboardService: TemplateDashboardService,private toasterService:ToastrService){ 
+    private viewTemplateService:ViewTemplateDrivenService,@Inject(DOCUMENT) private document: Document,private loaderService:LoaderService,private cd:ChangeDetectorRef,private templateDashboardService: TemplateDashboardService,private toasterService:ToastrService,private tallyService:TallyIntegrationService){
     localStorage.setItem('QuerySetId', '0');
     localStorage.setItem('customQuerySetId', '0');
 
@@ -213,6 +215,9 @@ export class WorkbenchComponent implements OnInit{
     else if(this.databaseSwitchType === 'HALOPS'){
     this.connectHaloPSA();
     }
+    else if(this.databaseSwitchType === 'TALLY'){
+    this.connectTally();
+    }
     else if(this.databaseSwitchType === 'IMMYBOT'){
     this.connectImmybot();
     }
@@ -269,6 +274,7 @@ export class WorkbenchComponent implements OnInit{
     path='';
     shopifyToken = '';
     shopifyName = '';
+    tallyToken = '';
 
     googleAnalytics: {
       type: string;
@@ -779,6 +785,28 @@ export class WorkbenchComponent implements OnInit{
       )
 
     }
+
+    tallyUpdate(){
+      const obj = {
+        "token_key": this.tallyToken,
+        "display_name": this.displayName,
+        "hierarchy_id": this.databaseId
+      }
+
+      this.tallyService.update(obj).subscribe({next: (res)=>{
+            this.modalService.dismissAll('close');
+            if(res){
+              this.toasterservice.success('Updated Successfully','success',{ positionClass: 'toast-top-right'});
+            }
+            this.getDbConnectionList();
+          },
+          error: (error) => {
+            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          }
+        }
+      )
+
+    }
     googleAnalyticsUpdate(){
       const g = this.googleAnalytics;
      const obj = { type: g.type,
@@ -945,6 +973,12 @@ export class WorkbenchComponent implements OnInit{
       this.viewNewDbs = false;
       this.emptyVariables();
     }
+    connectTally(){
+      this.openTallyForm = true;
+      this.databaseconnectionsList= false;
+      this.viewNewDbs = false;
+      this.emptyVariables();
+    }
     connectGoogleAnalytics(){
       this.openGoogleAnalyticsForm = true;
       this.databaseconnectionsList= false;
@@ -1061,6 +1095,13 @@ export class WorkbenchComponent implements OnInit{
         this.shopifyApiTokenError = false;
       }else{
         this.shopifyApiTokenError = true;
+      }
+    }
+    tallyTokenInputError(){
+      if(this.tallyToken){
+        this.tallyTokenError = false;
+      }else{
+        this.tallyTokenError = true;
       }
     }
     shopfyNameError(){
@@ -1280,6 +1321,34 @@ export class WorkbenchComponent implements OnInit{
           }
         }
       )
+    }
+
+    tallySignIn(){
+      const obj = {
+        "token_key": this.tallyToken,
+        "display_name": this.displayName
+      }
+      this.tallyService.create(obj).subscribe({next: (res)=>{
+        if(res){
+          this.toasterservice.success('Connected','success',{ positionClass: 'toast-top-right'});
+          this.databaseId = res?.hierarchy_id;
+          this.modalService.dismissAll();
+          if(!this.datasourceSwitchUI){
+          this.openTallyForm = false;
+          }
+          const encodedId = btoa(this.databaseId.toString());
+          if(this.iscrossDbSelect){
+            this.selectedHirchyIdCrsDb = this.databaseId
+            this.connectCrossDbs();
+          }else if(this.datasourceSwitchUI){
+            this.switchDatabase();
+          }else{
+            this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+          }
+        }
+      }, error: (error)=>{
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+      }});
     }
 
     mySqlSignIn(){
@@ -1959,6 +2028,9 @@ connectGoogleSheets(){
       this.displayName = editData.display_name;
       this.shopifyName = editData.shop_name;
       this.shopifyToken = editData.api_token;
+    } else if (this.databaseType == "tally") {
+      this.displayName = editData.display_name;
+      this.tallyToken = editData.token_key;
     }else if (this.databaseType === 'google_analytics') {
       this.googleAnalytics = {
         type: 'service_account',
@@ -2106,6 +2178,7 @@ connectGoogleSheets(){
   this.openConnectWiseForm = false;
   this.openHaloPSAForm = false;
   this.openShopifyForm = false;
+  this.openTallyForm = false;
   this.openGoogleAnalyticsForm = false;
   this.openGoogleAnalyticsForm = false;
   this.postGreServerName = '';
@@ -2123,6 +2196,8 @@ connectGoogleSheets(){
   this.siteURL = '';
   this.companyId = '';
   this.siteURLPSA = '';
+  this.tallyToken = '';
+  this.tallyTokenError = false;
   this.ninjaRMMClientid = '';
   this.ninjaRMMClientSecret = '';
   this.selectedNinjaRMMScopes = [];
@@ -2146,6 +2221,7 @@ connectGoogleSheets(){
 
   shopifyApiTokenError:boolean = false;
   shopifyNameError:boolean = false;
+  tallyTokenError:boolean = false;
 
   serverConditionError(){
     if(this.schemaList && this.schemaList.length > 0){

--- a/src/app/services/tally-integration.service.ts
+++ b/src/app/services/tally-integration.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TallyIntegrationService {
+  private baseUrl = 'http://13.57.231.251:50/v1/tally_authentication';
+  private token = 'OqDuhqGDLhMjgGqMQkCUxFl3027oQ9';
+
+  constructor(private http: HttpClient) { }
+
+  create(config: any) {
+    return this.http.post<any>(`${this.baseUrl}/${this.token}`, config);
+  }
+
+  update(config: any) {
+    return this.http.put<any>(`${this.baseUrl}/${this.token}`, config);
+  }
+
+  get() {
+    return this.http.get<any>(`${this.baseUrl}/${this.token}`);
+  }
+
+  delete(id?: any) {
+    const url = id ? `${this.baseUrl}/${this.token}/${id}` : `${this.baseUrl}/${this.token}`;
+    return this.http.delete<any>(url);
+  }
+}


### PR DESCRIPTION
## Summary
- add `TallyIntegrationService` for CRUD operations
- support Tally connection in workbench component
- display Tally connector in UI grids and forms
- include Tally type in transformation list and landing page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6858fa1440b08320991d709847a4f0d0