### PR TITLE
Refactor sheet charts to use saved options

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -71,6 +71,8 @@ export class InsightApexComponent {
   @Input() dataLabelsBarFontPosition:any;
   @Input() dataLabelsLineFontPosition:any;
   @Input() selectedColorScheme:any;
+  /** Saved options from backend for direct chart rendering */
+  @Input() savedChartOptions: any;
   @Input() SDKChartOptions: any;
   @Output() setDrilldowns = new EventEmitter<object>();
   @Output() saveOrUpdateChart = new EventEmitter<object>();
@@ -101,7 +103,10 @@ export class InsightApexComponent {
 
   ngOnChanges(changes: SimpleChanges) {
 
-    if(changes['SDKChartOptions']){
+    if(changes['savedChartOptions'] && this.savedChartOptions){
+      this.chartOptions = this.savedChartOptions;
+      this.chartType = this.chartType;
+    } else if(changes['SDKChartOptions']){
       this.chartOptions = this.SDKChartOptions;
       this.chartType = this.chartType;
     } else {

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -87,6 +87,8 @@ export class InsightEchartComponent {
   @Input() mapChartOptions:any;
   @Input() actionId:any;
   @Input() SDKChartOptions: any;
+  /** Saved options from backend for direct chart rendering */
+  @Input() savedChartOptions: any;
   @Input() isRadarDistribution:any;
   @Output() saveOrUpdateChart = new EventEmitter<object>();
   @Output() setDrilldowns = new EventEmitter<object>();
@@ -138,7 +140,7 @@ export class InsightEchartComponent {
     if(this.chartType === 'map'){
       this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
         echarts.registerMap('world', geoJson);
-        this.chartInstance?.setOption(this.SDKChartOptions ? this.SDKChartOptions :this.chartOptions,true);
+        this.chartInstance?.setOption(this.savedChartOptions ? this.savedChartOptions : (this.SDKChartOptions ? this.SDKChartOptions : this.chartOptions),true);
       });
     }
     else{
@@ -1910,7 +1912,18 @@ chartInitialize(){
   }
   ngOnChanges(changes: SimpleChanges) {
     
-     if(changes['SDKChartOptions']){
+     if(changes['savedChartOptions'] && this.savedChartOptions){
+      if(this.chartType === 'map'){
+        this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
+          echarts.registerMap('world', geoJson);
+          this.chartInstance?.setOption(this.savedChartOptions,true);
+        });
+      } else {
+        setTimeout(() => {
+          this.chartInstance?.setOption(this.savedChartOptions, true);
+        }, 100);
+      }
+     } else if(changes['SDKChartOptions']){
       if(this.chartType === 'map'){
         this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
           echarts.registerMap('world', geoJson);

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2505,7 +2505,7 @@
                                 @if(isApexCharts && !table && !kpi && !pivotTable){
               <!-- @if(bar && chartId){ -->
 
-                <app-insight-apex [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisColumnData]="dualAxisColumnData"
+                <app-insight-apex [savedChartOptions]="chartOptionsSet" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisColumnData]="dualAxisColumnData"
                 [dualAxisRowData]="dualAxisRowData" [tablePreviewRow]="tablePreviewRow" [chartType]="chartType" [xGridSwitch]="xGridSwitch"
                 [xLabelSwitch]="xLabelSwitch" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [xLabelFontFamily]="xLabelFontFamily"
                 [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [backgroundColor]="backgroundColor" [color]="color"
@@ -2528,7 +2528,7 @@
                     <div echarts [options]="eBarChartOptions" class="echart-charts"></div>
                 </div> -->
 
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor"
                 [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor"
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
@@ -2540,14 +2540,14 @@
             }
             @else if(funnel && chartId){         
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [color]="color" [backgroundColor]="backgroundColor" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed"
                     [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                 </div>
                 }
             @else if(stocked && chartId){         
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch"
                     [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment"
                     [xlabelAlignment]="xlabelAlignment" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
@@ -2558,7 +2558,7 @@
                 }
             @else if(sidebyside && chartId){         
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                         [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment" [selectedColorScheme]="selectedColorScheme"
                         [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [color]="color" [yGridColor]="yGridColor" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
@@ -2569,7 +2569,7 @@
                     }
             @else if(grouped && chartId){         
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch"  [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                         [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment"
                         [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [selectedColorScheme]="selectedColorScheme"
@@ -2580,7 +2580,7 @@
             }
             @else if(horizentalStocked && chartId){         
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch"  [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                     [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment" [selectedColorScheme]="selectedColorScheme"
                     [yLabelColor]="yLabelColor" [yGridColor]="yGridColor" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch"  [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily"
@@ -2591,7 +2591,7 @@
                 
             @else if(area && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" 
                 [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize"
                 [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor"
@@ -2602,7 +2602,7 @@
             }
             @else if(line && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" 
                 [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize"
                 [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor"
@@ -2614,7 +2614,7 @@
             }
             @else if(pie && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                 [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                 [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                 [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
@@ -2623,7 +2623,7 @@
             }
             @else if(donut && chartId){
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [donutSize]="donutSize" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [donutSize]="donutSize" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels" [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"
                     [donutDecimalPlaces]="donutDecimalPlaces" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
@@ -2633,7 +2633,7 @@
                 }
             @else if(barLine && chartId){
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [backgroundColor]="backgroundColor" [xLabelColor]="xLabelColor" [xLabelFontSize]="xLabelFontSize" [xLabelFontFamily]="xLabelFontFamily" [xLabelSwitch]="xLabelSwitch" [yLabelSwitch]="yLabelSwitch"
                     [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [barColor]="barColor" [lineColor]="lineColor"  [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                     [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor"
@@ -2643,7 +2643,7 @@
                 }
                 @else if(multiLine && chartId){
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch"  [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                         [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment"
                         [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [selectedColorScheme]="selectedColorScheme"
@@ -2654,7 +2654,7 @@
                     }
             @else if(radar && chartId){
                 <div class="card-body">
-                    <app-insight-echart  [chartType]="chartType" [color]="color"  [isBold]="isBold" [radarRowData]="radarRowData" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [savedChartOptions]="chartOptionsSet"  [chartType]="chartType" [color]="color"  [isBold]="isBold" [radarRowData]="radarRowData" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [xLabelColor]="xLabelColor" [dataLabels]="dataLabels" [dataLabelsFontFamily]="dataLabelsFontFamily"  [isRadarDistribution]="isRadarDistribution" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
@@ -2662,7 +2662,7 @@
                 }
                 @else if(map && chartId){
                     <div class="card-body">
-                        <app-insight-echart  [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet"  [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment"
                         [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily"
                         [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch"
@@ -2676,13 +2676,13 @@
                     
                 @else if(calendar){
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [selectedColorScheme]="selectedColorScheme"
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [selectedColorScheme]="selectedColorScheme"
                         [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                     </div>
                 }
                 @else if(heatMap){
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" 
+                        <app-insight-echart [savedChartOptions]="chartOptionsSet" [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" 
                         [decimalPlaces]="decimalPlaces" [displayUnits]="displayUnits"  [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [backgroundColor]="backgroundColor" [xLabelSwitch]="xLabelSwitch" [xLabelColor]="xLabelColor" [xLabelFontSize]="xLabelFontSize" [xLabelFontFamily]="xLabelFontFamily" [selectedColorScheme]="selectedColorScheme"
                         [xlabelFontWeight]="xlabelFontWeight" [yLabelSwitch]="yLabelSwitch" [yLabelColor]="yLabelColor" [yLabelFontSize]="[yLabelFontSize]" [yLabelFontFamily]="yLabelFontFamily" [ylabelFontWeight]="ylabelFontWeight"

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -50,6 +50,7 @@ import { InsightApexComponent } from '../insight-apex/insight-apex.component';
 import { InsightEchartComponent } from '../insight-echart/insight-echart.component';
 import { SharedService } from '../../../shared/services/shared.service';
 import { DefaultColorPickerService } from '../../../services/default-color-picker.service';
+import { ChartRenderService } from '../../../services/chart-render.service';
 import { FormatMeasurePipe } from '../../../shared/pipes/format-measure.pipe';
 // import $ from 'jquery';
 import { saveAs } from 'file-saver';
@@ -183,7 +184,9 @@ export class SheetsComponent{
   // The radius of the pie chart is half the smallest side
   public radius = Math.min(this.width, this.height) / 2 - this.margin;
   public colors:any;
+  /** @deprecated chartsColumnData is deprecated. Use savedChartOptions instead */
   chartsColumnData = [] as any;
+  /** @deprecated chartsRowData is deprecated. Use savedChartOptions instead */
   chartsRowData = [] as any;
   public lineChartOptions!: Partial<EChartsOption>;
   chartOptions:any;
@@ -446,7 +449,7 @@ export class SheetsComponent{
   is_sheet_Embed : boolean = false;
   isEmbedSDK: boolean = false;;
   constructor(private workbechService:WorkbenchService,private route:ActivatedRoute,private modalService: NgbModal,private router:Router,private zone: NgZone, private sanitizer: DomSanitizer,private cdr: ChangeDetectorRef,
-    private templateService:ViewTemplateDrivenService,private toasterService:ToastrService,private loaderService:LoaderService, private http: HttpClient, private colorService : DefaultColorPickerService,private sharedService: SharedService){   
+    private templateService:ViewTemplateDrivenService,private toasterService:ToastrService,private loaderService:LoaderService, private http: HttpClient, private colorService : DefaultColorPickerService,private sharedService: SharedService, private chartRenderService: ChartRenderService){
 
     if(this.router.url.includes('/analytify/sheets')){
       if (route.snapshot.params['id1'] && route.snapshot.params['id2']&& route.snapshot.params['id3'] ) {
@@ -1137,50 +1140,23 @@ try {
       }
       chartType : string ='';
       chartsOptionsSet(){
-        if (this.bar) {
-          this.chartType = 'bar';
-        }
-        else if(this.pivotTable){
-          this.chartType = 'pivotTable'
-        } else if (this.area) {
-          this.chartType = 'area';
-        } else if (this.line) {
-          this.chartType = 'line';
-        } else if (this.pie) {
-          this.chartType = 'pie';
-        } else if (this.sidebyside) {
-          this.chartType = 'sidebyside';
-        } else if (this.stocked) {
-          this.chartType = 'stocked';
-        } else if (this.barLine) {
-          this.chartType = 'barline';
-        } else if (this.horizentalStocked) {
-          this.chartType = 'hstocked';
-        } else if (this.grouped) {
-          this.chartType = 'hgrouped';
-        } else if (this.multiLine) {
-          this.chartType = 'multiline';
-        } else if (this.donut) {
-          this.chartType = 'donut';
-        } else if (this.radar) {
-          this.chartType = 'radar';
-        } else if (this.heatMap) {
-          this.chartType = 'heatmap';
-        } else if (this.kpi){
+        if(this.kpi){
           this.KPIChart();
-        } else if (this.funnel){
-          this.chartType = 'funnel';
-        }else if(this.guage){
-          this.chartType = 'guage';
-        } else if(this.map){
-          this.chartType = 'map';
-          this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
-            echarts.registerMap('world', geoJson);  // Register the map data
-          });
-        } else if(this.calendar){
-          this.chartType = 'calendar';
+          return;
         }
-
+        if(this.pivotTable){
+          this.chartType = 'pivotTable';
+          return;
+        }
+        const cfg = this.chartRenderService.getChartConfig(this.chartId);
+        if(cfg){
+          this.chartType = cfg.chartType;
+          if(cfg.chartType === 'map'){
+            this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
+              echarts.registerMap('world', geoJson);
+            });
+          }
+        }
       }
 
       KPIChart(){
@@ -2582,8 +2558,27 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
       this.draggedMeasureValuesData.push([res.column,res.data_type,"",res.alias ? res.alias : ""])
     });
   }
-  // this.table = false;
-  this.chartsDataSet(responce);
+
+  const savedOptions = responce?.sheet_data?.savedChartOptions;
+  if(savedOptions && typeof savedOptions === 'object'){
+    this.chartOptionsSet = savedOptions;
+    const cfg = this.chartRenderService.getChartConfig(responce.chart_id);
+    if(cfg){
+      const f = cfg.flags;
+      this.chartDisplay(f.table,f.bar,f.area,f.line,f.pie,f.sidebysideBar,f.stocked,f.barLine,f.horizentalStocked,f.grouped,f.multiLine,f.donut,f.radar,f.kpi,f.heatMap,f.funnel,f.guage,f.map,f.calendar,f.pivotTable,responce.chart_id);
+      this.chartType = cfg.chartType;
+      if(cfg.chartType === 'map'){
+        this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
+          echarts.registerMap('world', geoJson);
+        });
+      }
+      return;
+    }
+    console.warn('Unknown chart configuration for chart id', responce.chart_id);
+  } else {
+    console.warn('savedChartOptions missing or malformed, using legacy computation');
+    this.chartsDataSet(responce);
+  }
   if(responce.chart_id == 1){
     // this.tableData = this.sheetResponce.results.tableData;
     // this.displayedColumns = this.sheetResponce?.results.tableColumns;

--- a/src/app/services/chart-render.service.ts
+++ b/src/app/services/chart-render.service.ts
@@ -1,0 +1,79 @@
+import { Injectable } from '@angular/core';
+
+export interface ChartFlags {
+  table: boolean;
+  bar: boolean;
+  area: boolean;
+  line: boolean;
+  pie: boolean;
+  sidebysideBar: boolean;
+  stocked: boolean;
+  barLine: boolean;
+  horizentalStocked: boolean;
+  grouped: boolean;
+  multiLine: boolean;
+  donut: boolean;
+  radar: boolean;
+  kpi: boolean;
+  heatMap: boolean;
+  funnel: boolean;
+  guage: boolean;
+  map: boolean;
+  calendar: boolean;
+  pivotTable: boolean;
+}
+
+export interface ChartConfig {
+  chartType: string;
+  flags: ChartFlags;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ChartRenderService {
+  private baseFlags: ChartFlags = {
+    table: false,
+    bar: false,
+    area: false,
+    line: false,
+    pie: false,
+    sidebysideBar: false,
+    stocked: false,
+    barLine: false,
+    horizentalStocked: false,
+    grouped: false,
+    multiLine: false,
+    donut: false,
+    radar: false,
+    kpi: false,
+    heatMap: false,
+    funnel: false,
+    guage: false,
+    map: false,
+    calendar: false,
+    pivotTable: false,
+  };
+
+  private chartConfigMap: Record<number, ChartConfig> = {
+    6: { chartType: 'bar', flags: { ...this.baseFlags, bar: true } },
+    17: { chartType: 'area', flags: { ...this.baseFlags, area: true } },
+    13: { chartType: 'line', flags: { ...this.baseFlags, line: true } },
+    24: { chartType: 'pie', flags: { ...this.baseFlags, pie: true } },
+    7: { chartType: 'sidebyside', flags: { ...this.baseFlags, sidebysideBar: true } },
+    5: { chartType: 'stocked', flags: { ...this.baseFlags, stocked: true } },
+    4: { chartType: 'barline', flags: { ...this.baseFlags, barLine: true } },
+    2: { chartType: 'hstocked', flags: { ...this.baseFlags, horizentalStocked: true } },
+    3: { chartType: 'hgrouped', flags: { ...this.baseFlags, grouped: true } },
+    8: { chartType: 'multiline', flags: { ...this.baseFlags, multiLine: true } },
+    10: { chartType: 'donut', flags: { ...this.baseFlags, donut: true } },
+    12: { chartType: 'radar', flags: { ...this.baseFlags, radar: true } },
+    26: { chartType: 'heatmap', flags: { ...this.baseFlags, heatMap: true } },
+    27: { chartType: 'funnel', flags: { ...this.baseFlags, funnel: true } },
+    28: { chartType: 'guage', flags: { ...this.baseFlags, guage: true } },
+    29: { chartType: 'map', flags: { ...this.baseFlags, map: true } },
+    11: { chartType: 'calendar', flags: { ...this.baseFlags, calendar: true } },
+  };
+
+  getChartConfig(chartId: number): ChartConfig | undefined {
+    return this.chartConfigMap[chartId];
+  }
+}


### PR DESCRIPTION
## Summary
- centralize chart config with `ChartRenderService`
- deprecate old row/column chart data arrays
- inject chart config service into SheetsComponent
- use savedChartOptions when available
- feed savedChartOptions into `InsightApexComponent` and `InsightEchartComponent`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685928a53c688320ac739560afba9ef1