### PR TITLE
Add D3 customization bindings

### DIFF
--- a/src/app/components/workbench/insight-d3/insight-d3.component.html
+++ b/src/app/components/workbench/insight-d3/insight-d3.component.html
@@ -1,0 +1,1 @@
+<div class="chart-container" #chartContainer></div>

--- a/src/app/components/workbench/insight-d3/insight-d3.component.scss
+++ b/src/app/components/workbench/insight-d3/insight-d3.component.scss
@@ -1,0 +1,4 @@
+.chart-container {
+  width: 100%;
+  height: 400px;
+}

--- a/src/app/components/workbench/insight-d3/insight-d3.component.spec.ts
+++ b/src/app/components/workbench/insight-d3/insight-d3.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { InsightD3Component } from './insight-d3.component';
+
+describe('InsightD3Component', () => {
+  let component: InsightD3Component;
+  let fixture: ComponentFixture<InsightD3Component>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InsightD3Component]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InsightD3Component);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/workbench/insight-d3/insight-d3.component.ts
+++ b/src/app/components/workbench/insight-d3/insight-d3.component.ts
@@ -1,0 +1,451 @@
+import { Component, ElementRef, Input, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
+import * as d3 from 'd3';
+
+@Component({
+  selector: 'app-insight-d3',
+  standalone: true,
+  templateUrl: './insight-d3.component.html',
+  styleUrl: './insight-d3.component.scss'
+})
+export class InsightD3Component implements OnChanges {
+  @Input() chartOptions: any;
+  @Input() chartType!: string;
+  @Input() chartsRowData: any;
+  @Input() chartsColumnData: any;
+  @Input() dualAxisColumnData: any;
+  @Input() dualAxisRowData: any;
+  @Input() tablePreviewRow: any;
+
+  @Input() xGridSwitch: boolean = true;
+  @Input() yGridSwitch: boolean = true;
+  @Input() xLabelSwitch: boolean = true;
+  @Input() yLabelSwitch: boolean = true;
+  @Input() xLabelFontFamily: string = 'inherit';
+  @Input() xLabelFontSize: number = 12;
+  @Input() xlabelFontWeight: string = 'normal';
+  @Input() yLabelFontFamily: string = 'inherit';
+  @Input() yLabelFontSize: number = 12;
+  @Input() ylabelFontWeight: string = 'normal';
+  @Input() backgroundColor: string = '#ffffff';
+  @Input() color: string = 'steelblue';
+  @Input() barColor: string = '';
+  @Input() lineColor: string = '';
+  @Input() areaColor: string = '';
+  @Input() gridColor: string = '#e0e0e0';
+  @Input() legendSwitch: boolean = true;
+  @Input() dataLabels: boolean = false;
+  @Input() label: any;
+  @Input() donutSize: number = 0;
+  @Input() isDistributed: boolean = false;
+  @Input() minValueGuage: any;
+  @Input() maxValueGuage: any;
+  @Input() legendsAllignment: any;
+  @Input() dataLabelsFontFamily: string = 'inherit';
+  @Input() dataLabelsFontSize: number = 12;
+  @Input() dataLabelsFontPosition: any;
+  @Input() dataLabelsColor: string = '#000';
+  @Input() measureAlignment: any;
+  @Input() dimensionAlignment: any;
+  @Input() displayUnits: any;
+  @Input() decimalPlaces: any;
+  @Input() prefix: string = '';
+  @Input() suffix: string = '';
+  @Input() donutDecimalPlaces: any;
+  @Input() drillDownIndex: any;
+  @Input() draggedDrillDownColumns: any;
+  @Input() drillDownObject: any;
+  @Input() sortType: any;
+  @Input() isSheetSaveOrUpdate: any;
+  @Input() dataLabelsBarFontPosition: any;
+  @Input() dataLabelsLineFontPosition: any;
+  @Input() selectedColorScheme: string[] = [];
+  @Input() measureColor: string = '';
+  @Input() dimensionColor: string = '';
+  @Input() xGridColor: string = '#e0e0e0';
+  @Input() xLabelColor: string = '#000';
+  @Input() yGridColor: string = '#e0e0e0';
+  @Input() yLabelColor: string = '#000';
+  @Input() isZoom: boolean = false;
+
+  @ViewChild('chartContainer', { static: true }) chartContainer!: ElementRef;
+
+  ngOnChanges(_changes: SimpleChanges): void {
+    this.renderChart();
+  }
+
+  private clear(): void {
+    d3.select(this.chartContainer.nativeElement).selectAll('*').remove();
+  }
+
+  private renderChart(): void {
+    if (!this.chartOptions) return;
+    this.clear();
+
+    switch (this.chartType) {
+      case 'bar':
+        this.renderBar();
+        break;
+      case 'line':
+        this.renderLine();
+        break;
+      case 'area':
+        this.renderArea();
+        break;
+      case 'pie':
+      case 'donut':
+        this.renderPie();
+        break;
+      case 'scatter':
+      case 'bubble':
+        this.renderScatter();
+        break;
+      default:
+        console.warn(`Unsupported chart type: ${this.chartType}`);
+    }
+  }
+
+  private renderBar(): void {
+    const data = this.chartOptions.series?.[0]?.data || [];
+    const labels = this.chartOptions.xaxis?.categories || [];
+    const width = this.chartContainer.nativeElement.clientWidth;
+    const height = 400;
+    const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+
+    const svg = d3
+      .select(this.chartContainer.nativeElement)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .style('background-color', this.backgroundColor);
+
+    const x = d3
+      .scaleBand()
+      .domain(labels)
+      .range([margin.left, width - margin.right])
+      .padding(0.1);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data) || 0])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    svg
+      .append('g')
+      .attr('fill', this.barColor || this.color || this.chartOptions.colors?.[0] || 'steelblue')
+      .selectAll('rect')
+      .data(data)
+      .enter()
+      .append('rect')
+      .attr('x', (_d, i) => x(labels[i])!)
+      .attr('y', (d: number) => y(d))
+      .attr('height', (d: number) => y(0) - y(d))
+      .attr('width', x.bandwidth());
+
+    const xAxis = svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).tickSize(this.xGridSwitch ? -height + margin.top + margin.bottom : 0));
+    xAxis.selectAll('line').attr('stroke', this.xGridColor);
+    xAxis.selectAll('text')
+      .style('display', this.xLabelSwitch ? null : 'none')
+      .attr('font-family', this.xLabelFontFamily)
+      .attr('font-size', this.xLabelFontSize)
+      .attr('font-weight', this.xlabelFontWeight)
+      .attr('fill', this.xLabelColor);
+
+    const yAxis = svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).tickSize(this.yGridSwitch ? -width + margin.left + margin.right : 0));
+    yAxis.selectAll('line').attr('stroke', this.yGridColor);
+    yAxis.selectAll('text')
+      .style('display', this.yLabelSwitch ? null : 'none')
+      .attr('font-family', this.yLabelFontFamily)
+      .attr('font-size', this.yLabelFontSize)
+      .attr('font-weight', this.ylabelFontWeight)
+      .attr('fill', this.yLabelColor);
+
+    if (this.dataLabels) {
+      svg
+        .append('g')
+        .selectAll('text')
+        .data(data)
+        .enter()
+        .append('text')
+        .attr('x', (_d, i) => (x(labels[i])! + x.bandwidth() / 2))
+        .attr('y', (d: number) => y(d) - 4)
+        .attr('text-anchor', 'middle')
+        .attr('font-family', this.dataLabelsFontFamily)
+        .attr('font-size', this.dataLabelsFontSize)
+        .attr('font-weight', this.isBold ? 'bold' : 'normal')
+        .attr('fill', this.dataLabelsColor)
+        .text(d => d);
+    }
+  }
+
+  private renderLine(): void {
+    const data = this.chartOptions.series?.[0]?.data || [];
+    const labels = this.chartOptions.xaxis?.categories || [];
+    const width = this.chartContainer.nativeElement.clientWidth;
+    const height = 400;
+    const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+
+    const svg = d3
+      .select(this.chartContainer.nativeElement)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .style('background-color', this.backgroundColor);
+
+    const x = d3
+      .scalePoint()
+      .domain(labels)
+      .range([margin.left, width - margin.right]);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data) || 0])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const line = d3
+      .line<number>()
+      .x((d, i) => x(labels[i])!)
+      .y(d => y(d));
+
+    svg
+      .append('path')
+      .datum(data)
+      .attr('fill', 'none')
+      .attr('stroke', this.lineColor || this.color || this.chartOptions.colors?.[0] || 'steelblue')
+      .attr('stroke-width', 1.5)
+      .attr('d', line);
+
+    const xAxis = svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).tickSize(this.xGridSwitch ? -height + margin.top + margin.bottom : 0));
+    xAxis.selectAll('line').attr('stroke', this.xGridColor);
+    xAxis.selectAll('text')
+      .style('display', this.xLabelSwitch ? null : 'none')
+      .attr('font-family', this.xLabelFontFamily)
+      .attr('font-size', this.xLabelFontSize)
+      .attr('font-weight', this.xlabelFontWeight)
+      .attr('fill', this.xLabelColor);
+
+    const yAxis = svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).tickSize(this.yGridSwitch ? -width + margin.left + margin.right : 0));
+    yAxis.selectAll('line').attr('stroke', this.yGridColor);
+    yAxis.selectAll('text')
+      .style('display', this.yLabelSwitch ? null : 'none')
+      .attr('font-family', this.yLabelFontFamily)
+      .attr('font-size', this.yLabelFontSize)
+      .attr('font-weight', this.ylabelFontWeight)
+      .attr('fill', this.yLabelColor);
+
+    if (this.dataLabels) {
+      svg
+        .append('g')
+        .selectAll('text')
+        .data(data)
+        .enter()
+        .append('text')
+        .attr('x', (_d, i) => x(labels[i])!)
+        .attr('y', d => y(d) - 4)
+        .attr('text-anchor', 'middle')
+        .attr('font-family', this.dataLabelsFontFamily)
+        .attr('font-size', this.dataLabelsFontSize)
+        .attr('font-weight', this.isBold ? 'bold' : 'normal')
+        .attr('fill', this.dataLabelsColor)
+        .text(d => d);
+    }
+  }
+
+  private renderArea(): void {
+    const data = this.chartOptions.series?.[0]?.data || [];
+    const labels = this.chartOptions.xaxis?.categories || [];
+    const width = this.chartContainer.nativeElement.clientWidth;
+    const height = 400;
+    const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+
+    const svg = d3
+      .select(this.chartContainer.nativeElement)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .style('background-color', this.backgroundColor);
+
+    const x = d3
+      .scalePoint()
+      .domain(labels)
+      .range([margin.left, width - margin.right]);
+
+    const y = d3
+      .scaleLinear()
+      .domain([0, d3.max(data) || 0])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const area = d3
+      .area<number>()
+      .x((d, i) => x(labels[i])!)
+      .y0(y(0))
+      .y1(d => y(d));
+
+    svg
+      .append('path')
+      .datum(data)
+      .attr('fill', this.areaColor || this.color || this.chartOptions.colors?.[0] || 'steelblue')
+      .attr('d', area);
+
+    const xAxis = svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).tickSize(this.xGridSwitch ? -height + margin.top + margin.bottom : 0));
+    xAxis.selectAll('line').attr('stroke', this.xGridColor);
+    xAxis.selectAll('text')
+      .style('display', this.xLabelSwitch ? null : 'none')
+      .attr('font-family', this.xLabelFontFamily)
+      .attr('font-size', this.xLabelFontSize)
+      .attr('font-weight', this.xlabelFontWeight)
+      .attr('fill', this.xLabelColor);
+
+    const yAxis = svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).tickSize(this.yGridSwitch ? -width + margin.left + margin.right : 0));
+    yAxis.selectAll('line').attr('stroke', this.yGridColor);
+    yAxis.selectAll('text')
+      .style('display', this.yLabelSwitch ? null : 'none')
+      .attr('font-family', this.yLabelFontFamily)
+      .attr('font-size', this.yLabelFontSize)
+      .attr('font-weight', this.ylabelFontWeight)
+      .attr('fill', this.yLabelColor);
+
+    if (this.dataLabels) {
+      svg
+        .append('g')
+        .selectAll('text')
+        .data(data)
+        .enter()
+        .append('text')
+        .attr('x', (_d, i) => x(labels[i])!)
+        .attr('y', d => y(d) - 4)
+        .attr('text-anchor', 'middle')
+        .attr('font-family', this.dataLabelsFontFamily)
+        .attr('font-size', this.dataLabelsFontSize)
+        .attr('font-weight', this.isBold ? 'bold' : 'normal')
+        .attr('fill', this.dataLabelsColor)
+        .text(d => d);
+    }
+  }
+
+  private renderPie(): void {
+    const data = this.chartOptions.series || [];
+    const labels = this.chartOptions.labels || [];
+    const width = 400;
+    const height = 400;
+    const radius = Math.min(width, height) / 2;
+
+    const svg = d3
+      .select(this.chartContainer.nativeElement)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+      .attr('transform', `translate(${width / 2},${height / 2})`);
+
+    const color = d3
+      .scaleOrdinal<string>()
+      .range(this.selectedColorScheme.length ? this.selectedColorScheme : (this.chartOptions.colors || d3.schemeCategory10));
+
+    const arc = d3
+      .arc<d3.PieArcDatum<number>>()
+      .innerRadius(this.chartType === 'donut' ? radius * (this.donutSize || 0.5) : 0)
+      .outerRadius(radius);
+
+    const pie = d3.pie<number>().value(d => d);
+
+    const slices = svg
+      .selectAll('path')
+      .data(pie(data))
+      .enter()
+      .append('path')
+      .attr('d', arc as any)
+      .attr('fill', (d, i) => color(labels[i]));
+
+    if (this.legendSwitch) {
+      const legend = svg
+        .append('g')
+        .attr('transform', `translate(${radius + 20},${-radius})`);
+      labels.forEach((l, i) => {
+        const g = legend.append('g').attr('transform', `translate(0, ${i * 20})`);
+        g.append('rect').attr('width', 12).attr('height', 12).attr('fill', color(l));
+        g.append('text').attr('x', 16).attr('y', 10).text(l).attr('font-size', 12);
+      });
+    }
+  }
+
+  private renderScatter(): void {
+    const data = this.chartOptions.series?.[0]?.data || [];
+    const width = this.chartContainer.nativeElement.clientWidth;
+    const height = 400;
+    const margin = { top: 20, right: 20, bottom: 30, left: 40 };
+
+    const svg = d3
+      .select(this.chartContainer.nativeElement)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height)
+      .style('background-color', this.backgroundColor);
+
+    const x = d3
+      .scaleLinear()
+      .domain(d3.extent(data, (d: any) => d[0]) as [number, number])
+      .nice()
+      .range([margin.left, width - margin.right]);
+
+    const y = d3
+      .scaleLinear()
+      .domain(d3.extent(data, (d: any) => d[1]) as [number, number])
+      .nice()
+      .range([height - margin.bottom, margin.top]);
+
+    const xAxis = svg
+      .append('g')
+      .attr('transform', `translate(0,${height - margin.bottom})`)
+      .call(d3.axisBottom(x).tickSize(this.xGridSwitch ? -height + margin.top + margin.bottom : 0));
+    xAxis.selectAll('line').attr('stroke', this.xGridColor);
+    xAxis.selectAll('text')
+      .style('display', this.xLabelSwitch ? null : 'none')
+      .attr('font-family', this.xLabelFontFamily)
+      .attr('font-size', this.xLabelFontSize)
+      .attr('font-weight', this.xlabelFontWeight)
+      .attr('fill', this.xLabelColor);
+
+    const yAxis = svg
+      .append('g')
+      .attr('transform', `translate(${margin.left},0)`)
+      .call(d3.axisLeft(y).tickSize(this.yGridSwitch ? -width + margin.left + margin.right : 0));
+    yAxis.selectAll('line').attr('stroke', this.yGridColor);
+    yAxis.selectAll('text')
+      .style('display', this.yLabelSwitch ? null : 'none')
+      .attr('font-family', this.yLabelFontFamily)
+      .attr('font-size', this.yLabelFontSize)
+      .attr('font-weight', this.ylabelFontWeight)
+      .attr('fill', this.yLabelColor);
+
+    svg
+      .selectAll('circle')
+      .data(data)
+      .enter()
+      .append('circle')
+      .attr('cx', (d: any) => x(d[0]))
+      .attr('cy', (d: any) => y(d[1]))
+      .attr('r', this.chartType === 'bubble' ? (d: any) => d[2] || 5 : 5)
+      .attr('fill', this.color || this.chartOptions.colors?.[0] || 'steelblue');
+  }
+}

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2520,7 +2520,22 @@
                 [dataLabelsLineFontPosition]="dataLabelsLineFontPosition" [selectedColorScheme]="selectedColorScheme"
                 (saveOrUpdateChart)="setChartOptions($event)" (setDrilldowns)="setDrilldowns($event)">
                 </app-insight-apex>
-    
+            } @else if(isD3Charts && !table && !kpi && !pivotTable){
+                <app-insight-d3 [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisColumnData]="dualAxisColumnData"
+                [dualAxisRowData]="dualAxisRowData" [tablePreviewRow]="tablePreviewRow" [chartType]="chartType" [xGridSwitch]="xGridSwitch"
+                [xLabelSwitch]="xLabelSwitch" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [xLabelFontFamily]="xLabelFontFamily"
+                [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [backgroundColor]="backgroundColor" [color]="color"
+                [ylabelFontWeight]="ylabelFontWeight" [isBold]="isBold" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize"
+                [barColor]="barColor" [lineColor]="lineColor" [gridColor]="GridColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"
+                [label]="label" [donutSize]="donutSize" [isDistributed]="isDistributed" [minValueGuage]="minValueGuage" [maxValueGuage]="maxValueGuage"
+                [legendsAllignment]="legendsAllignment" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize"
+                [dataLabelsFontPosition]="dataLabelsFontPosition" [dataLabelsColor]="dataLabelsColor" [measureAlignment]="measureAlignment"
+                [dimensionAlignment]="dimensionAlignment" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
+                [donutDecimalPlaces]="donutDecimalPlaces" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"
+                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition"
+                [dataLabelsLineFontPosition]="dataLabelsLineFontPosition" [selectedColorScheme]="selectedColorScheme"
+                (saveOrUpdateChart)="setChartOptions($event)" (setDrilldowns)="setDrilldowns($event)">
+                </app-insight-d3>
             } @else {
             @if(bar && chartId){         
             <div class="card-body">
@@ -3766,9 +3781,10 @@
                                                                             <div class="form-group mb-0 p-0">
                                                                                 <select class="form-select form-select select2 fs-14" [(ngModel)]="selectedChartPlugin"
                                                                                     (change)="customizechangeChartPlugin()">
-                                                                                    <option *ngIf="!(radar || calendar || map)" value="apex">Basic</option>
-                                                                                    <option *ngIf="!(guage)" value="echart">Advanced</option>
-                                                                                </select>
+            <option *ngIf="!(radar || calendar || map)" value="apex">Basic</option>
+            <option *ngIf="!(guage)" value="echart">Advanced</option>
+            <option value="d3">D3</option>
+        </select>
                                                                             </div>
                                                     
                                                                             <span ngbTooltip=""></span>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -48,6 +48,7 @@ import { lastValueFrom, Subscription, timer } from 'rxjs';
 import { evaluate, i, parse } from 'mathjs';
 import { InsightApexComponent } from '../insight-apex/insight-apex.component';
 import { InsightEchartComponent } from '../insight-echart/insight-echart.component';
+import { InsightD3Component } from '../insight-d3/insight-d3.component';
 import { SharedService } from '../../../shared/services/shared.service';
 import { DefaultColorPickerService } from '../../../services/default-color-picker.service';
 import { FormatMeasurePipe } from '../../../shared/pipes/format-measure.pipe';
@@ -103,7 +104,7 @@ declare var $:any;
   ],
   imports: [SharedModule, NgxEchartsModule, NgSelectModule,NgbModule,FormsModule,ReactiveFormsModule,MatIconModule,NgxColorsModule,
     CdkDropListGroup, CdkDropList,CommonModule, CdkDrag,NgApexchartsModule,MatTabsModule,MatFormFieldModule,MatInputModule,CKEditorModule,
-    InsightsButtonComponent,NgxSliderModule,NgxPaginationModule,MatTooltipModule,InsightApexComponent,InsightEchartComponent,FormatMeasurePipe,ScrollingModule,TestPipe,CustomSheetsComponent,NgbTooltipModule],
+    InsightsButtonComponent,NgxSliderModule,NgxPaginationModule,MatTooltipModule,InsightApexComponent,InsightEchartComponent,InsightD3Component,FormatMeasurePipe,ScrollingModule,TestPipe,CustomSheetsComponent,NgbTooltipModule],
   templateUrl: './sheets.component.html',
   styleUrl: './sheets.component.scss'
 })
@@ -137,9 +138,10 @@ export class SheetsComponent{
   errorMessage : any;
   errorMessage1:any;
   userPrompt: string = '';
-  selectedChartPlugin : string = '';	
+  selectedChartPlugin : string = '';
   isApexCharts : boolean = true;
   isEChatrts : boolean = false;
+  isD3Charts : boolean = false;
   isZoom : boolean = false;
   xLabelFontSize : number = 12;
   yLabelFontSize : number = 12;
@@ -4138,9 +4140,15 @@ customizechangeChartPlugin() {
   if (this.selectedChartPlugin == 'apex') {
     this.isApexCharts = true;
     this.isEChatrts = false;
+    this.isD3Charts = false;
+  } else if (this.selectedChartPlugin == 'd3') {
+    this.isApexCharts = false;
+    this.isEChatrts = false;
+    this.isD3Charts = true;
   } else {
     this.isApexCharts = false;
     this.isEChatrts = true;
+    this.isD3Charts = false;
   }
   // this.reAssignChartData();
 }
@@ -4149,9 +4157,15 @@ customizechangeChartPlugin() {
     if (this.selectedChartPlugin == 'apex') {
       this.isApexCharts = true;
       this.isEChatrts = false;
+      this.isD3Charts = false;
+    } else if (this.selectedChartPlugin == 'd3') {
+      this.isApexCharts = false;
+      this.isEChatrts = false;
+      this.isD3Charts = true;
     } else {
       this.isApexCharts = false;
       this.isEChatrts = true;
+      this.isD3Charts = false;
     }
     // if(this.retriveDataSheet_id){
     //   if((this.sheetResponce.isEChart && this.isEChatrts && (this.sheetChartId === this.chartId)) || (this.sheetResponce.isApexChart && this.isApexCharts && (this.sheetChartId === this.chartId))){


### PR DESCRIPTION
## Summary
- expose a large set of inputs on `InsightD3Component` so it accepts the same customization options as Apex/EChart
- rework chart rendering methods to apply colors, grid toggles, label fonts and data labels using those inputs
- wire `SheetsComponent` template to pass customization options when rendering D3 charts

## Testing
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: Cannot find module '@angular/core')*
- `npx ng test --watch=false` *(fails: npm 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_685966676160832084641c7b4beee05f