### PR TITLE
Add bar chart animations

### DIFF
--- a/src/app/components/workbench/insight-d3/insight-d3.component.ts
+++ b/src/app/components/workbench/insight-d3/insight-d3.component.ts
@@ -129,7 +129,7 @@ export class InsightD3Component implements OnChanges {
       .nice()
       .range([height - margin.bottom, margin.top]);
 
-    svg
+    const bars = svg
       .append('g')
       .attr('fill', this.barColor || this.color || this.selectedColorScheme[0])
       .selectAll('rect')
@@ -137,9 +137,16 @@ export class InsightD3Component implements OnChanges {
       .enter()
       .append('rect')
       .attr('x', (_d, i) => x(labels[i])!)
-      .attr('y', (d: number) => y(d))
-      .attr('height', (d: number) => y(0) - y(d))
+      .attr('y', y(0))
+      .attr('height', 0)
       .attr('width', x.bandwidth());
+
+    bars
+      .transition()
+      .duration(800)
+      .ease(d3.easeCubicOut)
+      .attr('y', (d: number) => y(d))
+      .attr('height', (d: number) => y(0) - y(d));
 
     const xAxis = svg
       .append('g')

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -275,11 +275,14 @@ export class InsightEchartComponent {
             fontSize:this.dataLabelsFontSize,
             fontWeight:this.isBold ? 700 : 400,
             color:this.dataLabelsColor,
-            formatter:(params:any) => this.formatNumber(params.value) 
+            formatter:(params:any) => this.formatNumber(params.value)
            },
           type: 'bar',
           barWidth: '80%',
-          data: this.chartsRowData
+          data: this.chartsRowData,
+          animation: true,
+          animationDuration: 1000,
+          animationEasing: 'cubicOut'
           // data: this.chartsRowData.map((value: any, index: number) => ({
           //   value,
           //   itemStyle: { color: this.isDistributed ? this.selectedColorScheme[index % this.selectedColorScheme.length] : this.color  }
@@ -1200,7 +1203,7 @@ barLineChart(){
         data: this.dualAxisRowData[0]?.data,
         itemStyle:{
           color:this.barColor, // Default bar color
-          
+
       },
         label:{
           show:true,
@@ -1209,8 +1212,11 @@ barLineChart(){
           fontWeight:this.isBold ? 700 : 400,
           position:this.dataLabelsBarFontPosition,
           align:'center',
-          formatter:(params:any) => this.formatNumber(params.value) 
-        }
+          formatter:(params:any) => this.formatNumber(params.value)
+        },
+        animation: true,
+        animationDuration: 1000,
+        animationEasing: 'cubicOut'
       },
 
       {
@@ -1792,11 +1798,14 @@ let barChartOptions = {
         fontSize:this.dataLabelsFontSize,
         fontWeight:this.isBold ? 700 : 400,
         color: this.dataLabelsColor,
-        formatter:(params:any) => this.formatNumber(params.value) 
+        formatter:(params:any) => this.formatNumber(params.value)
        },
       type: 'bar',
       barWidth: '80%',
-      data: this.chartsRowData
+      data: this.chartsRowData,
+      animation: true,
+      animationDuration: 1000,
+      animationEasing: 'cubicOut'
       // data: this.chartsRowData.map((value: any, index: number) => ({
       //   value,
       //   itemStyle: { borderWidth: '50px' }


### PR DESCRIPTION
## Summary
- animate ECharts bar charts with smooth cubic easing
- add D3 transitions so bars grow from height 0

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_685b81c84440832082f43ec927358139