### PR TITLE
Enhance HubSpot scope selection

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -1474,7 +1474,32 @@
                         </div>
                         <div class="form-group">
                           <label [ngClass]="{'error-label': hubspotScopeError}" class="col-form-label">Scopes <span class="text-danger ms-1">*</span></label>
-                          <ng-select [items]="hubspotScopes" bindLabel="" placeholder="Select Scopes" [(ngModel)]="selectedHubspotScopes" [multiple]="true" (change)="onHubspotScopeChange($event)"></ng-select>
+                          <ng-select
+                            #hubspotSelect
+                            [items]="hubspotScopes"
+                            bindLabel=""
+                            placeholder="Select Scopes"
+                            [(ngModel)]="selectedHubspotScopes"
+                            [multiple]="true"
+                            [searchable]="true"
+                            [closeOnSelect]="false"
+                            (change)="onHubspotScopeChange($event)">
+                            <ng-template ng-header-tmp>
+                              <div class="d-flex justify-content-end p-1">
+                                <button type="button" class="btn btn-sm btn-link" (click)="selectAllHubspotScopes()">Select All</button>
+                              </div>
+                            </ng-template>
+                            <ng-template ng-option-tmp let-item="item">
+                              <div class="form-check m-0">
+                                <input
+                                  type="checkbox"
+                                  class="form-check-input me-2"
+                                  [checked]="hubspotSelect.isSelected(item)"
+                                  tabindex="-1" />
+                                <label class="form-check-label">{{ item }}</label>
+                              </div>
+                            </ng-template>
+                          </ng-select>
                         </div>
                         <div class="modal-footer">
                           <button type="button" class="btn btn-secondary" (click)="gotoNewConnections()">Close</button>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -1212,6 +1212,11 @@ export class WorkbenchComponent implements OnInit{
       this.selectedHubspotScopes = event;
       this.hubspotScopeError = this.selectedHubspotScopes.length <= 0;
     }
+
+    selectAllHubspotScopes(): void {
+      this.selectedHubspotScopes = [...this.hubspotScopes];
+      this.hubspotScopeError = false;
+    }
     shopifySignIn(){
       const obj={
         "api_token":this.shopifyToken,


### PR DESCRIPTION
## Summary
- keep HubSpot scope dropdown open when selecting
- add Select All feature for HubSpot scopes
- display checkboxes for each HubSpot scope option

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6863dc215e38832094e993a31b1519cb