### PR TITLE
Add SAP HANA connector

### DIFF
--- a/src/app/components/workbench/landingpage/landingpage.component.html
+++ b/src/app/components/workbench/landingpage/landingpage.component.html
@@ -533,6 +533,10 @@
                                         <img alt="product" src="./assets/images/icons/postSQL-icon.jpg"
                                             class="w-5 h-5 border me-2">{{database.server_type | lowercase}}
                                     </td>
+                                    <td *ngIf="database.server_type === 'SAP HANA'">
+                                        <img alt="product" src="./assets/images/Db_server_images/Multi dimensional  Database/SAP-HANA.png"
+                                            class="w-5 h-5 border me-2">{{database.server_type | lowercase}}
+                                    </td>
                                     <td *ngIf="database.server_type === 'TALLY'">
                                         <img alt="product" src="./assets/images/icons/TallyLogo.png"
                                             class="w-5 h-5 border me-2">{{database.server_type | lowercase}}

--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -1827,7 +1827,89 @@
           </div>
           
             } 
-          @if(openMongoDbForm){
+            @if(openSapHanaForm){
+              <div class="main-container container-fluid px-4 TopHeader" >
+                <div class="row">
+                    <div class="col-md-12 col-xl-6 p-1 mb-0">
+                        <div class="card Relational-database-height">
+                            <div class="card-header">
+                                <h4 class="card-title">Connect To SAP HANA</h4>
+                            </div>
+                            <div class="card-body">
+                                <form>
+                                        <div class="form-group">
+                                            <label [ngClass]="{'error-label': serverError}" for="recipient-name" class="col-form-label">Server<span class="text-danger ms-1" >*</span></label>
+                                            <input [ngClass]="{'error-input': serverError}" type="text" class="form-control" [(ngModel)]="postGreServerName" [ngModelOptions]="{standalone: true}" placeholder="Host Name/Host Url" (input)="serverConditionError()">
+                                        </div>
+                                        <div class="form-group">
+                                            <label [ngClass]="{'error-label': portError}" for="message-text" class="col-form-label">Port<span class="text-danger ms-1" >*</span></label>
+                                            <input [ngClass]="{'error-input': portError}" type="text" class="form-control" [(ngModel)]="postGrePortName" [ngModelOptions]="{standalone: true}" placeholder="e.g. 443" (input)="portConditionError()">
+                                        </div>
+                                        <div class="form-group">
+                                            <label [ngClass]="{'error-label': databaseError}" class="col-form-label">Database</label>
+                                            <input [ngClass]="{'error-input': databaseError}" type="text" class="form-control" [(ngModel)]="postGreDatabaseName" [ngModelOptions]="{standalone: true}" placeholder="e.g. SAPHDB" (input)="databaseConditionError()">
+                                        </div>
+                                        <div class="form-group">
+                                            <label [ngClass]="{'error-label': userNameError}" class="col-form-label">User Name <span class="text-danger ms-1" >*</span></label>
+                                            <input [ngClass]="{'error-input': userNameError}" type="text" class="form-control" [(ngModel)]="postGreUserName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. Admin" (input)="userNameConditionError()">
+                                        </div>
+                                        <div class="mb-2">
+                                          <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1" >*</span></label>
+                                          <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. SAP" (input)="displayNameConditionError()">
+                                        </div>
+                                        <div class="form-group">
+                                            <label [ngClass]="{'error-label': passwordError}" class="col-form-label">Password <span class="text-danger ms-1" >*</span></label>
+                                            <div class="d-flex">
+                                              <input [ngClass]="{'error-input': passwordError}" type="password" class="form-control" [(ngModel)]="PostGrePassword" [ngModelOptions]="{standalone: true}" autocomplete="new-mypswd" [type]="showPassword1 ? 'text' : 'password'" placeholder="e.g. ******" (input)="passwordConditionError()">
+                                              <button class="btn btn-light" (click)="toggleVisibility1()" type="button" id="button-addon21"><i class="ri-eye-{{toggleClass1}} align-middle"></i></button>
+                                            </div>
+                                    </div>
+                                    @if(schemaList && schemaList.length > 0) {
+                                    <div class="form-group">
+                                      <label class="col-form-label">Select Schema </label>
+                                      <select id="schemaupdateSelect" [(ngModel)]="selectedSchema" [ngModelOptions]="{standalone: true}" class="form-select">
+                                        <option value="" disabled selected>Select Schema</option>
+                                        <option *ngFor="let schema of schemaList" [value]="schema">{{ schema }}</option>
+                                      </select>
+                                    </div>
+                                  }
+                                  <div class="modal-footer">
+                                    <button type="button" class="btn btn-primary" (click)="fetchSchemaList()" [disabled]="disableConnectBtn">Fetch Schema</button>
+                                      <button type="button" class="btn btn-secondary" (click)="datasourceSwitchUI ? gotoDashboardWithoutSwitch() : gotoNewConnections()" >Close</button>
+                                      <button type="button" *ngIf="!datasourceSwitchUI" class="btn btn-primary" (click)="sapHanaSignIn()" [disabled]="disableConnectBtn">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+                                      <button type="button" *ngIf="datasourceSwitchUI" class="btn btn-primary" (click)="sapHanaSignIn()" [disabled]="disableConnectBtn">Connect & Switch</button>
+                                  </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-md-12 col-xl-6 p-1 mb-0">
+                      <div class="card user-card border Relational-database-height">
+                        <div class="user-image" >
+                            <span class="avatar w-20 h-20 rounded-circle mb-2 user-image-outline" >
+                              <img src="./assets/images/Db_server_images/Multi dimensional  Database/SAP-HANA.png" alt="" class="rounded-circle bg-white user-image-border-color" >
+                            </span>
+                        </div>
+                        <div class="card-body server-content-card">
+                          <ul class="">
+                            <li> <span class="mt-1">SAP HANA is an in-memory, column-oriented, relational database management system developed by SAP.</span></li>
+                          </ul>
+                          <ul class="mt-2">
+                            <li><span class="mb-0"><strong>Server:</strong> Place your host url or host name </span> </li>
+                            <li><span class="mb-0"><strong>Port:</strong> Example port number for SAP HANA is 443 </span> </li>
+                            <li><span class="mb-0"><strong>Database:</strong> Provide your database name if applicable</span> </li>
+                            <li><span class="mb-0"><strong>Schema:</strong> Provide schema name if database is not specified</span> </li>
+                            <li><span class="mb-0"><strong>Username:</strong> Enter your username in this field</span> </li>
+                            <li><span class="mb-0"><strong>Password:</strong> Please give your password in this field</span> </li>
+                          </ul>
+                        </div>
+                     </div>
+                    </div>
+                </div>
+            </div>
+
+            }
+            @if(openMongoDbForm){
             <div class="main-container container-fluid px-4 TopHeader">
               <div class="row">
                   <div class="col-md-12 col-xl-6 p-1 mb-0">
@@ -2173,7 +2255,7 @@
                         </div>
                       </div>
                       <div class="database-logo">
-                        <div class="imgcard op-4 p-4">
+                        <div class="imgcard p-4" (click)="openSapHana(); errorCheck()">
                           <img src="./assets/images/Db_server_images/Multi dimensional  Database/SAP-HANA.png" alt="Image"
                             class="card-img" />
                         </div>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -63,6 +63,7 @@ export class WorkbenchComponent implements OnInit{
   openMicrosoftSqlServerForm = false;
   openSnowflakeServerForm = false;
   openMongoDbForm = false;
+  openSapHanaForm = false;
   openTallyForm = false;
   sqlLiteForm = false;
   openTablesUI = false;
@@ -932,23 +933,29 @@ export class WorkbenchComponent implements OnInit{
 )
     }
     DatabaseUpdate(){
-      const obj={
-          // "database_type":"postgresql",
+      const obj:any = {
           "database_type":this.databaseType,
           "hostname":this.postGreServerName,
           "port":this.postGrePortName,
           "username":this.postGreUserName,
           "password":this.PostGrePassword,
-          "database": this.postGreDatabaseName,
           "display_name":this.displayName,
           "database_id":this.databaseId,
-          "schema": this.selectedSchema
-      }as any
+      };
       if(this.databaseType === 'oracle'){
-        delete obj.database
-        obj.service_name=this.postGreDatabaseName;
+        obj.service_name = this.postGreDatabaseName;
+      }else if(this.databaseType === 'sap hana'){
+        if(this.postGreDatabaseName){
+          obj.database = this.postGreDatabaseName;
+        }
+        if(this.selectedSchema){
+          obj.schema = this.selectedSchema;
+        }
+      }else{
+        obj.database = this.postGreDatabaseName;
+        obj.schema = this.selectedSchema;
       }
-        this.workbechService.postGreSqlConnectionput(obj).subscribe({next: (responce) => {
+      this.workbechService.postGreSqlConnectionput(obj).subscribe({next: (responce) => {
               console.log(responce);
               this.modalService.dismissAll('close');
               this.schemaList = [];
@@ -1733,6 +1740,62 @@ export class WorkbenchComponent implements OnInit{
       });
     }
 
+    openSapHana(){
+      this.openSapHanaForm = true;
+      this.databaseconnectionsList = false;
+      this.viewNewDbs = false;
+      this.emptyVariables();
+      this.selectedSchema = '';
+    }
+
+    sapHanaSignIn(){
+      const obj:any = {
+          "database_type":"sap hana",
+          "hostname":this.postGreServerName,
+          "port":this.postGrePortName,
+          "username":this.postGreUserName,
+          "password":this.PostGrePassword,
+          "display_name":this.displayName,
+      };
+      if(this.postGreDatabaseName){
+        obj.database = this.postGreDatabaseName;
+      }
+      if(this.selectedSchema){
+        obj.schema = this.selectedSchema;
+      }
+      this.confirmPopupForDataTransformation().then((isSkip) => {
+        if (isSkip === true) {
+          this.workbechService.postGreSqlConnection(obj).subscribe({next: (responce) => {
+                if(responce){
+                  this.toasterservice.success('Connected','success',{ positionClass: 'toast-top-right'});
+                  this.databaseId=responce.database?.hierarchy_id;
+                  this.modalService.dismissAll();
+                  if(!this.datasourceSwitchUI){
+                  this.openSapHanaForm = false;
+                  }
+                  const encodedId = btoa(this.databaseId.toString());
+                  if(this.iscrossDbSelect){
+                    this.selectedHirchyIdCrsDb = this.databaseId;
+                    this.connectCrossDbs();
+                  }else if(this.datasourceSwitchUI){
+                    this.switchDatabase();
+                  }else{
+                    this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+                  }
+                }
+              },
+              error: (error) => {
+                console.log(error);
+                this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'});
+              }
+            }
+          )
+        } else if(isSkip === false) {
+          this.checkDataSourceConnection(obj);
+        }
+      });
+    }
+
     opensqlLite(){
       this.sqlLiteForm=true;
       this.databaseconnectionsList= false;
@@ -2217,7 +2280,7 @@ connectGoogleSheets(){
       } else {
         this.postGreDatabaseName = editData.database;
       }
-      if(this.databaseType == 'postgresql'){
+      if(this.databaseType == 'postgresql' || this.databaseType == 'sap hana'){
         this.selectedSchema = editData.schema;
       }
       this.errorCheck();
@@ -2333,6 +2396,7 @@ connectGoogleSheets(){
   this.openMicrosoftSqlServerForm = false;
   this.openSnowflakeServerForm = false;
   this.ibmDb2Form= false;
+  this.openSapHanaForm = false;
   this.sqlLiteForm = false;
   this.openConnectWiseForm = false;
   this.openHaloPSAForm = false;
@@ -2415,14 +2479,22 @@ connectGoogleSheets(){
   }
   databaseConditionError(){
     if(this.schemaList && this.schemaList.length > 0){
-      this.selectedSchema = 'public';
+      this.selectedSchema = this.openSapHanaForm ? '' : 'public';
       this.schemaList = [];
     }
+    if(this.openSapHanaForm){
+      if(this.postGreDatabaseName || this.selectedSchema){
+        this.databaseError = false;
+      }else{
+        this.databaseError = true;
+      }
+    } else {
       if (this.postGreDatabaseName) {
         this.databaseError = false;
       } else {
         this.databaseError = true;
       }
+    }
     this.portConditionError();
     this.errorCheck();
   }
@@ -2498,6 +2570,15 @@ connectGoogleSheets(){
         } else{
           this.disableConnectBtn = false;
         }
+      }
+    } 
+    else if(this.openSapHanaForm){
+      if(this.serverError || this.portError || this.userNameError || this.displayNameError || this.passwordError || this.databaseError){
+        this.disableConnectBtn = true;
+      } else if(!(this.postGreServerName && this.postGrePortName && this.postGreUserName && this.displayName && this.PostGrePassword && (this.postGreDatabaseName || this.selectedSchema))) {
+        this.disableConnectBtn = true;
+      } else{
+        this.disableConnectBtn = false;
       }
     }
     else if(this.serverError || this.portError || this.databaseError || this.userNameError || this.displayNameError || this.passwordError){
@@ -2613,14 +2694,16 @@ connectGoogleSheets(){
 
   fetchSchemaList() {
     this.loaderService.show();
-    const obj = {
-      "database_type": "postgresql",
+    const obj:any = {
+      "database_type": this.openSapHanaForm ? "sap hana" : "postgresql",
       "hostname": this.postGreServerName,
       "port": this.postGrePortName,
       "username": this.postGreUserName,
       "password": this.PostGrePassword,
-      "database": this.postGreDatabaseName,
       "display_name": this.displayName
+    };
+    if(this.postGreDatabaseName){
+      obj.database = this.postGreDatabaseName;
     }
     this.workbechService.fetchSchemaList(obj).subscribe({
       next: (responce) => {


### PR DESCRIPTION
## Summary
- add SAP HANA form and sign-in logic
- handle optional database or schema validation
- support schema fetch for SAP HANA
- reset SAP HANA state when closing forms
- expose SAP HANA option in DB selection UI
- add SAP HANA display logic on landing page

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686538f222fc83208b40f21ad6f2b149