### PR TITLE
Implement protected sharing flow

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { authen } from './shared/routes/authenticationroutes';
 // import { landing } from './shared/routes/landingroutes';
 import { workbench } from './shared/routes/workbenckroutes';
 import { WorkbenchLayoutsComponent } from './shared/layout-components/layouts/workbench-layouts/workbench-layouts.component';
+import { authGuard } from './auth.guard';
 export const App_Route: Route[] = [
       { path: '', redirectTo: 'authentication/login', pathMatch: 'full' },
       {
@@ -16,6 +17,12 @@ export const App_Route: Route[] = [
       },
       {
         path: 'public/dashboard/:id1',
+        loadComponent: () =>
+          import('../app/components/workbench/sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
+      },
+      {
+        path: 'dashboard/share/protected/:id1',
+        canActivate: [authGuard],
         loadComponent: () =>
           import('../app/components/workbench/sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
       },

--- a/src/app/auth.guard.spec.ts
+++ b/src/app/auth.guard.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
-import { CanActivateFn } from '@angular/router';
+import { CanActivateFn, Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { authGuard } from './auth.guard';
 
@@ -7,11 +8,23 @@ describe('authGuard', () => {
   const executeGuard: CanActivateFn = (...guardParameters) => 
       TestBed.runInInjectionContext(() => authGuard(...guardParameters));
 
+  let router: Router;
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule]
+    });
+    router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
   });
 
   it('should be created', () => {
     expect(executeGuard).toBeTruthy();
+  });
+
+  it('should redirect to login with returnUrl when not authenticated', () => {
+    localStorage.removeItem('currentUser');
+    const result = executeGuard({} as any, { url: '/protected/url' } as any);
+    expect(result).toBeFalse();
+    expect(router.navigate).toHaveBeenCalledWith(['authentication/login'], { queryParams: { returnUrl: '/protected/url' }});
   });
 });

--- a/src/app/auth.guard.ts
+++ b/src/app/auth.guard.ts
@@ -9,6 +9,6 @@ export const authGuard: CanActivateFn = (route, state) => {
   if(currentUser){
     return true;
   }
-  _router.navigate(['authentication/login'])
+  _router.navigate(['authentication/login'], { queryParams: { returnUrl: state.url }});
   return false;
 };

--- a/src/app/components/authentication/login/login.component.ts
+++ b/src/app/components/authentication/login/login.component.ts
@@ -2,7 +2,7 @@ import { DOCUMENT } from '@angular/common';
 import { Component, ElementRef, Inject, Renderer2 } from '@angular/core';
 import { FormBuilder, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { DomSanitizer } from '@angular/platform-browser';
-import { Router, RouterModule } from '@angular/router';
+import { Router, RouterModule, ActivatedRoute } from '@angular/router';
 import { AuthService } from '../../../shared/services/auth.service';
 import Swal from 'sweetalert2';
 import { RolespriviledgesService } from '../../workbench/rolespriviledges.service';
@@ -21,6 +21,8 @@ import { LoaderService } from '../../../shared/services/loader.service';
 export class LoginComponent {
 
 loginForm:FormGroup;
+
+returnUrl: string | null = null;
 
 
 showPassword = false;
@@ -44,10 +46,11 @@ toggleVisibility1() {
   }
 }
   constructor(
-    @Inject(DOCUMENT) private document: Document,private elementRef: ElementRef,private router: Router,private switcherComponent: SwitcherComponent,private themeService : CustomThemeService,
+    @Inject(DOCUMENT) private document: Document,private elementRef: ElementRef,private router: Router,private route: ActivatedRoute,private switcherComponent: SwitcherComponent,private themeService : CustomThemeService,
     private renderer: Renderer2, private rolesService : RolespriviledgesService, private sanitizer: DomSanitizer,private formBuilder:FormBuilder,private authService:AuthService,private loaderService : LoaderService
   ) {
     const currentUser = localStorage.getItem('currentUser');
+    this.returnUrl = this.route.snapshot.queryParamMap.get('returnUrl');
     if (currentUser) {
       this.router.navigate(['analytify/home']);
     }
@@ -99,7 +102,11 @@ this.authService.login(this.f['email'].value,this.f['password'].value)
       this.rolesService.setRoleBasedPreviledges(data.previlages);
     }
     if(data.accessToken){
-      this.router.navigate(['analytify/home'])
+      if(this.returnUrl){
+        this.router.navigateByUrl(this.returnUrl);
+      } else {
+        this.router.navigate(['analytify/home']);
+      }
     }
   },
   error:(error:any)=>{

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.html
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.html
@@ -180,6 +180,7 @@
             <ng-select class="form-control p-0" name="choices-multiple-remove-button" id="choices-multiple-remove-button" (change)="sharePublish($event)" [closeOnSelect]="true" placeholder="Share or Publish">
              <ng-option  value="public" selected>Public</ng-option>
              <ng-option  value="private" selected>Private</ng-option>
+             <ng-option  value="protected" selected>Protected</ng-option>
             </ng-select>
        </div>
           <div *ngIf="shareAsPrivate" class="">
@@ -197,6 +198,10 @@
                 <ng-option *ngFor="let user of usersOnSelectedRole" [value]="user.user_id">{{user.username}}</ng-option>
               
             </ng-select>
+       </div>
+       <div *ngIf="shareAsProtected" class="">
+        <p class="fw-semibold mb-2 mt-3">Pass Key</p>
+        <input type="password" class="form-control" [(ngModel)]="passKey" placeholder="Enter Pass Key" />
        </div>
        <div *ngIf="publishedDashboard" class="">
             
@@ -223,6 +228,7 @@
       <div class="modal-footer">
         <button type="button" [disabled]="!selectedRoleIds?.length || !selectedUserIds?.length" *ngIf="!createUrl && !applyButtonEnableOnEditUser" (click)="saveDashboardProperties()" class="btn ripple btn-primary">Apply</button>
         <button type="button" [disabled]="!shareAsPrivate" *ngIf="applyButtonEnableOnEditUser" (click)="saveDashboardProperties()" class="btn ripple btn-primary">Update</button>
+        <button type="button" [disabled]="passKey.length < 6" *ngIf="shareAsProtected" (click)="createProtectedShare()" class="btn ripple btn-primary">Apply</button>
 
         <button
           type="button"

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
@@ -40,6 +40,8 @@ export class DashboardPageComponent implements OnInit{
   createUrl =false;
   publicUrl:any;
   shareAsPrivate = false;
+  shareAsProtected = false;
+  passKey: string = '';
   dashboardPropertyId:any;
   publishedDashboard = false;
   port:any;
@@ -348,12 +350,19 @@ sharePublish(value:any){
   if(value === 'public'){
     this.createUrl = true;
     this.shareAsPrivate = false
+    this.shareAsProtected = false;
     const publicDashboardId = btoa(this.dashboardId.toString());
     this.publicUrl = 'https://'+this.host+':'+this.port+'/public/dashboard/'+publicDashboardId;
     this.publishDashboard();
   } else if(value === 'private'){
     this.createUrl = false;
     this.shareAsPrivate = true;
+    this.shareAsProtected = false;
+    this.publishedDashboard = false;
+  } else if(value === 'protected'){
+    this.createUrl = true;
+    this.shareAsPrivate = false;
+    this.shareAsProtected = true;
     this.publishedDashboard = false;
   }
   }
@@ -392,9 +401,9 @@ fallbackCopyTextToClipboard(text: string): void {
   }
   document.body.removeChild(textArea);
 }
-publishDashboard(){
-  this.workbechService.publishDashbord(this.dashboardPropertyId).subscribe({
-    next:(data)=>{
+  publishDashboard(){
+    this.workbechService.publishDashbord(this.dashboardPropertyId).subscribe({
+      next:(data)=>{
       console.log(data);
       this.toasterservice.success('Dashboard Published','success',{ positionClass: 'toast-center-center'})
       this.publishedDashboard = true;
@@ -403,6 +412,23 @@ publishDashboard(){
       console.log(error);
       this.toasterservice.error('Dashboard Published','error',{ positionClass: 'toast-center-center'})
 
+    }
+  })
+}
+
+createProtectedShare(){
+  if(!this.passKey || this.passKey.length < 6){
+    this.toasterservice.error('Passkey must be at least 6 characters','error',{ positionClass: 'toast-top-right'});
+    return;
+  }
+  const obj = { dashboardId: this.dashboardId, passKey: this.passKey };
+  this.workbechService.protectedShare(obj).subscribe({
+    next:(data)=>{
+      this.publicUrl = data.protectedShareUrl;
+      this.publishedDashboard = true;
+    },
+    error:(error)=>{
+      this.toasterservice.error(error.error.message || 'Failed to create link','error',{ positionClass: 'toast-top-right'});
     }
   })
 }

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -2404,7 +2404,22 @@
      [ngStyle]="{ boxShadow: genieHover ? '0 8px 24px rgba(0,0,0,0.28)' : '0 4px 16px rgba(0,0,0,0.18)' }">
   <img src="assets/images/analyze-genieaiq1.webp" alt="Genie AIQ" class="overlay-img"/>
 <div class="genie-tooltip" *ngIf="showGenieTooltip">
-    Analyze Dashboard
-  </div>
+  Analyze Dashboard
 </div>
+</div>
+
+<ng-template #passKeyModal let-modal>
+  <div class="modal-header">
+    <h6 class="modal-title">Enter Pass Key</h6>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss('Cross click')"></button>
+  </div>
+  <div class="modal-body">
+    <input type="password" class="form-control" [(ngModel)]="enteredPassKey" placeholder="Pass Key" />
+    <div class="text-danger mt-2" *ngIf="passKeyError">{{passKeyError}}</div>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn ripple btn-secondary" (click)="modal.dismiss('Close click')">Cancel</button>
+    <button type="button" class="btn ripple btn-primary" [disabled]="enteredPassKey.length < 6" (click)="verifyPassKey(modal)">Apply</button>
+  </div>
+</ng-template>
 

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectorRef, Component, ElementRef, HostListener, QueryList, ViewChild, ViewChildren, OnDestroy } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, HostListener, QueryList, ViewChild, ViewChildren, OnDestroy, AfterViewInit } from '@angular/core';
 import { NgbDropdown, NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ResizableModule, ResizeEvent } from 'angular-resizable-element';
 import {CompactType, GridsterConfig, GridsterItem, GridsterItemComponent, GridsterItemComponentInterface, GridsterModule, GridsterPush, 
@@ -127,7 +127,7 @@ export class CustomVirtualScrollStrategy extends FixedSizeVirtualScrollStrategy 
   templateUrl: './sheetsdashboard.component.html',
   styleUrl: './sheetsdashboard.component.scss'
 })
-export class SheetsdashboardComponent implements OnDestroy {
+export class SheetsdashboardComponent implements OnDestroy, AfterViewInit {
  // @HostListener('window:resize', ['$event'])
  itemsPerPage:any;
   private destroy$ = new Subject<void>();
@@ -195,6 +195,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   public chartOptions!: Partial<ChartOptions>;
   searchSheets!: string;
   isPublicUrl = false;
+  isProtectedUrl = false;
   publicHeader = false;
   columnSearch: any;
   rolesForUpdateDashboard:[] = [];
@@ -232,6 +233,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   @ViewChild('analyzeDashbaordModal') analyzeDashbaordModal:any;
   @ViewChild('textEditorModal') textEditorModal!: any;
   @ViewChild('ImageUploadText') ImageUploadText!: ElementRef;
+  @ViewChild('passKeyModal') passKeyModal!: any;
   textItem: any;
   textEditorContent: string = '';
   textEditorTitle: string = '';
@@ -246,6 +248,8 @@ export class SheetsdashboardComponent implements OnDestroy {
   isEmbeddedFilter : boolean = false;
   genieHover = false;
   showGenieTooltip = false;
+  enteredPassKey: string = '';
+  passKeyError: string = '';
 
 
   constructor(private workbechService:WorkbenchService,private route:ActivatedRoute,private router:Router,private screenshotService: ScreenshotService,
@@ -263,6 +267,15 @@ export class SheetsdashboardComponent implements OnDestroy {
       this.publicHeader = true
       if (route.snapshot.params['id1']) {
       this.dashboardId = +atob(route.snapshot.params['id1'])
+      }
+    }
+    if(currentUrl.includes('dashboard/share/protected')){
+      this.updateDashbpardBoolen= true;
+      this.isProtectedUrl = true;
+      this.active = 2;
+      this.publicHeader = true;
+      if(route.snapshot.params['id1']){
+        this.dashboardId = +atob(route.snapshot.params['id1']);
       }
     }
     if(currentUrl.includes('analytify/sheetscomponent/sheetsdashboard')){
@@ -591,7 +604,7 @@ export class SheetsdashboardComponent implements OnDestroy {
     };
     if(this.dashboardToken){
       this.fetchDashboardIdFromToken();
-    } else {
+    } else if(!this.isProtectedUrl){
       this.initialiserMethods();
     }
     //this.getSheetData();
@@ -3139,6 +3152,9 @@ arraysHaveSameData(arr1: number[], arr2: number[]): boolean {
   ngAfterViewInit() {
     if(this.isEmbedDashboard){
       this.toggleSidebar();
+    }
+    if(this.isProtectedUrl){
+      this.modalService.open(this.passKeyModal, { backdrop: 'static', keyboard: false });
     }
     this.dashboard.forEach(item => {
       this.initializeChart(item);
@@ -8762,6 +8778,25 @@ resetGenieAnimation() {
   if (el) {
     el.classList.remove('bounce');
   }
+}
+
+verifyPassKey(modal: any){
+  if(!this.enteredPassKey || this.enteredPassKey.length < 6){
+    this.passKeyError = 'Passkey must be at least 6 characters';
+    return;
+  }
+  const obj = { dashboardId: this.dashboardId, passKey: this.enteredPassKey };
+  this.workbechService.verifyPassKey(obj).subscribe({
+    next:()=>{
+      this.passKeyError = '';
+      modal.close();
+      this.isPublicUrl = true;
+      this.initialiserMethods();
+    },
+    error:(error)=>{
+      this.passKeyError = error.error.message || 'Invalid passkey';
+    }
+  });
 }
 }
 // export interface CustomGridsterItem extends GridsterItem {

--- a/src/app/components/workbench/workbench.routes.ts
+++ b/src/app/components/workbench/workbench.routes.ts
@@ -341,6 +341,12 @@ export const admin: Routes = [
           import('./sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
       },
       {
+        path: 'dashboard/share/protected/:id1',
+        canActivate: [authGuard],
+        loadComponent: () =>
+          import('./sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
+      },
+      {
         path: 'configure-page/configure',
         canActivate: [authGuard],
         loadComponent: () =>

--- a/src/app/components/workbench/workbench.service.spec.ts
+++ b/src/app/components/workbench/workbench.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { WorkbenchService } from './workbench.service';
+import { environment } from '../../environments/environment';
+
+describe('WorkbenchService', () => {
+  let service: WorkbenchService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule]
+    });
+    service = TestBed.inject(WorkbenchService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should POST to protected-share', () => {
+    const payload = { dashboardId: 1, passKey: 'secret' };
+    service.protectedShare(payload).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/dashboard/protected-share`);
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+  });
+
+  it('should POST to verify-passkey', () => {
+    const payload = { dashboardId: 1, passKey: 'secret' };
+    service.verifyPassKey(payload).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/dashboard/verify-passkey`);
+    expect(req.request.method).toBe('POST');
+    req.flush({});
+  });
+});

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -700,6 +700,18 @@ deleteUser(id:any){
   publishDashbord(id:any){
     return this.http.get<any>(`${environment.apiUrl}/is_public/`+id);
   }
+
+  protectedShare(obj:any){
+    const currentUser = localStorage.getItem('currentUser');
+    this.accessToken = JSON.parse(currentUser!)['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/dashboard/protected-share`, obj);
+  }
+
+  verifyPassKey(obj:any){
+    const currentUser = localStorage.getItem('currentUser');
+    this.accessToken = JSON.parse(currentUser!)['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/dashboard/verify-passkey`, obj);
+  }
   getDashboardFilterredListPublic(obj:any){
     return this.http.post<any>(`${environment.apiUrl}/public/dashboard_filter_list/`,obj); 
   }


### PR DESCRIPTION
## Summary
- add protected share URL routes
- redirect unauthenticated users back to protected link after login
- support protected share option in dashboard properties with passkey
- verify passkey before loading protected dashboards
- expose protected share APIs in workbench service
- add tests for auth guard redirect and service integration

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ab74baf4c832097912ac3636b1b27