### PR TITLE
Add OpenAI Smart Dashboard

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1032,6 +1032,11 @@ deleteUser(id:any){
       this.accessToken = JSON.parse(currentUser!)['Token'];
       return this.http.get<any>(`${environment.apiUrl}/ninja_dashbaord/` + id + '/' + this.accessToken);
     }
+    buildSampleOpenAIDashboard(id: number){
+      const currentUser = localStorage.getItem( 'currentUser' );
+      this.accessToken = JSON.parse( currentUser! )['Token'];
+      return this.http.get<any>(`${environment.apiUrl}/open_ai_dashboard/`+id+'/'+this.accessToken);
+    }
     buildSampleSalesforceDashbaord(id : number){
       const currentUser = localStorage.getItem( 'currentUser' );
       this.accessToken = JSON.parse( currentUser! )['Token'];

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -1554,7 +1554,24 @@ export class WorkbenchComponent implements OnInit{
           }else if(this.datasourceSwitchUI){
             this.switchDatabase();
           }else{
-            this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+            Swal.fire({
+              position: "center",
+              iconHtml: '<img src="./assets/images/copilot.gif">',
+              title: "Create smart dashboard from your data with just one click?",
+              showConfirmButton: true,
+              showCancelButton: true,
+              confirmButtonText: 'Yes',
+              cancelButtonText: 'Skip',
+              customClass: {
+                icon: 'no-icon-bg',
+              }
+            }).then((result) => {
+              if (result.isConfirmed) {
+                this.templateDashboardService.buildSampleOpenAIDashboard(this.container, this.databaseId);
+              } else {
+                this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+              }
+            });
           }
         }
       }, error:(error)=>{

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -1021,6 +1021,37 @@ export class TemplateDashboardService {
       }
     )
     this.buildDashboardResponseData(responce,'salesforce');
+      },
+      error: (error) => {
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+        console.log(error);
+      }
+    }
+  )
+  }
+
+  buildSampleOpenAIDashboard(container: ViewContainerRef , databaseId: any){
+    const componentRef =container.createComponent(InsightEchartComponent);
+    this.echartInstance = componentRef.instance;
+    this.workbechService.buildSampleOpenAIDashboard(databaseId).subscribe({next: (responce) => {
+      const obj ={
+        query_set_id:responce.datasource_query.queryset_id,
+        hierarchy_id:responce.datasource_query.hierarchy_id,
+        joining_tables: responce.datasource_query.joining_tables,
+        join_type:responce.datasource_query.join_type,
+        joining_conditions:responce.datasource_query.joining_conditions,
+        dragged_array: {dragged_array:responce.datasource_query.dragged_array,dragged_array_indexing:{}},
+      } as any
+      this.workbechService.joiningTablesTest(obj).subscribe({next: (res) => {
+        this.buildDashboardResponseData(res,'openai');
+          },
+          error: (error) => {
+            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+            console.log(error);
+          }
+        }
+      )
+      this.buildDashboardResponseData(responce,'openai');
         },
         error: (error) => {
           this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})


### PR DESCRIPTION
## Summary
- integrate OpenAI dashboard API
- add OpenAI sample dashboard builder in template service
- prompt for smart dashboard creation after OpenAI sign‑in

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686abf1f81d0832087f6db7e5ca9edb9