### PR TITLE
Handle updated dashboardTransfer response

### DIFF
--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -331,9 +331,16 @@ export class TemplateDashboardService {
         join_type:query.join_type,
         joining_conditions:query.joining_conditions,
         dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-      responesData.sheets.forEach((sheet: any)=> {
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: () => {},
+        error: (error) => {
+          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          console.log(error);
+        }
+      });
+    });
+    responesData.sheets.forEach((sheet: any)=> {
         const {
           chart_id,
           sheet_col,
@@ -429,20 +436,14 @@ export class TemplateDashboardService {
           }
         }
       });
-        let responseData = _.cloneDeep(this.mergeSheetData(responesData));
-        this.updateDashboardData(responseData.dashboard, responseData.sheets).then(() => {
-          this.dashboardInstance.dashboardId = responesData.dashboard.dashboard_id;
-          this.dashboardInstance.assignDashboardParams(responseData.dashboard,true);
-          // this.dashboardInstance.updateDashboard(false,false,true);
-        }).catch(error => {
-          console.error('Error updating dashboard data:', error);
-        });
-        },
-        error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-          console.log(error);
-        }
-      });
+    });
+    let responseData = _.cloneDeep(this.mergeSheetData(responesData));
+    this.updateDashboardData(responseData.dashboard, responseData.sheets).then(() => {
+      this.dashboardInstance.dashboardId = responesData.dashboard.dashboard_id;
+      this.dashboardInstance.assignDashboardParams(responseData.dashboard,true);
+      // this.dashboardInstance.updateDashboard(false,false,true);
+    }).catch(error => {
+      console.error('Error updating dashboard data:', error);
     });
   }
 

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -322,16 +322,17 @@ export class TemplateDashboardService {
     this.sheetsInstance = componentRef.instance;
     const dashboardComponentRef =container.createComponent(SheetsdashboardComponent);
     this.dashboardInstance = dashboardComponentRef.instance;
-    const obj ={
-      query_set_id:responesData.datasource_query.queryset_id,
-      hierarchy_id:responesData.datasource_query.hierarchy_id,
-      joining_tables: responesData.datasource_query.joining_tables,
-      join_type:responesData.datasource_query.join_type,
-      joining_conditions:responesData.datasource_query.joining_conditions,
-      dragged_array: {dragged_array:responesData.datasource_query.dragged_array,dragged_array_indexing:{}},
-    } as any
-    let responseData = _.cloneDeep(this.mergeSheetData(responesData));
-    this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
+    const queries = Array.isArray(responesData.datasource_query) ? responesData.datasource_query : [responesData.datasource_query];
+    queries.forEach((query: any) => {
+      const obj ={
+        query_set_id:query.queryset_id,
+        hierarchy_id:query.hierarchy_id,
+        joining_tables: query.joining_tables,
+        join_type:query.join_type,
+        joining_conditions:query.joining_conditions,
+        dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
+      } as any
+      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
       responesData.sheets.forEach((sheet: any)=> {
         const {
           chart_id,
@@ -441,8 +442,8 @@ export class TemplateDashboardService {
           this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
           console.log(error);
         }
-      }
-    )
+      });
+    });
   }
 
   mergeSheetData(data: any) {


### PR DESCRIPTION
## Summary
- update `buildDashboardTransfer` to support array `datasource_query`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cbb5c8c0c8320abcdf2eb1f841432