### PR TITLE
Update dashboard transfer workflow

### DIFF
--- a/src/app/components/workbench/dashboard-transfer/dashboard-transfer.component.html
+++ b/src/app/components/workbench/dashboard-transfer/dashboard-transfer.component.html
@@ -61,6 +61,7 @@
                     type="text"
                     class="form-control"
                     [(ngModel)]="importKey"
+                    (change)="onImportKeyChange()"
                     name="importKey"
                     placeholder="Enter Import Key"
                     required

--- a/src/app/components/workbench/dashboard-transfer/dashboard-transfer.component.ts
+++ b/src/app/components/workbench/dashboard-transfer/dashboard-transfer.component.ts
@@ -5,7 +5,6 @@ import { WorkbenchService } from '../workbench.service';
 import { TemplateDashboardService } from '../../../services/template-dashboard.service';
 import { ToastrService } from 'ngx-toastr';
 import { SharedModule } from '../../../shared/sharedmodule';
-import { forkJoin } from 'rxjs';
 
 /**
  * Component for importing and exporting dashboards.
@@ -32,22 +31,33 @@ export class DashboardTransferComponent {
   ) {}
 
   ngOnInit(){
-    forkJoin({
-      responseA:  this.workbenchService.getdatabaseConnectionsList({need_pagination : false, need_cross_datasources: false}),
-      responseB: this.workbenchService.getuserDashboardsList()
-    }).subscribe({
-      next: ({ responseA, responseB }) => {
-        this.connectionsList = responseA;
-        this.dashboardList = responseB;
-        // this.loading = false;
+    this.workbenchService.getuserDashboardsList().subscribe({
+      next: (response: any) => {
+        this.dashboardList = response;
       },
       error: (err) => {
-        console.error('Error loading APIs', err);
-        // this.loading = false;
+        console.error('Error loading dashboards', err);
       }
     });
-    // this.getDashboardsList();
-    // this.getdatabaseConnectionsList();
+  }
+
+  /** Fetch connections linked to the provided import key */
+  onImportKeyChange(){
+    if(!this.importKey){
+      this.connectionsList = [];
+      this.hierarchyId = undefined as any;
+      return;
+    }
+    const payload = { dashboard_import_id: this.importKey };
+    this.workbenchService.getSharedConnections(payload).subscribe({
+      next: (res: any) => {
+        this.connectionsList = res;
+      },
+      error: err => {
+        console.error('Error fetching connections', err);
+        this.toastr.error(err.error?.message || 'Failed to load connections');
+      }
+    });
   }
 
   getdatabaseConnectionsList(){

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1063,6 +1063,14 @@ deleteUser(id:any){
       return this.http.post<any>(`${environment.apiUrl}/import_dashboard/`+this.accessToken,object);
     }
 
+    /**
+     * Fetch list of shared connections for a given dashboard import id.
+     * @param object request payload containing dashboard_import_id
+     */
+    getSharedConnections(object: any){
+      return this.http.post<any>(`${environment.apiUrl}/shared_connections`, object);
+    }
+
     getSheetSdkData(object:any){
       const currentUser = localStorage.getItem( 'currentUser' );
       this.accessToken = JSON.parse( currentUser! )['Token'];


### PR DESCRIPTION
## Summary
- fetch shared connections only after the import key is entered
- add `getSharedConnections` API helper
- update dashboard transfer component to load connections on key change

## Testing
- `npm test` *(fails: ng not found)*
- `npx ng test` *(fails: 403 Forbidden because of lack of internet)*

------
https://chatgpt.com/codex/tasks/task_b_68715bc45bfc8320a02c54e5ed803fa9