### PR TITLE
Add Smart Dashboard action menu

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1027,6 +1027,13 @@ deleteUser(id:any){
       return this.http.get<any>(`${environment.apiUrl}/salesforce_dashbaord/`+id+'/'+this.accessToken);
     }
 
+    createSmartDashboard(hierarchyId: number){
+      return this.http.post<any>(
+        'http://127.0.0.1:8000/v1/smart_dashboard_create/eETAlQhNbqQS0IT8QVe5j7AdJ4AZwX',
+        { hierarchy_id: hierarchyId }
+      );
+    }
+
     fetchSDKData(){
       const currentUser = localStorage.getItem( 'currentUser' );
       this.accessToken = JSON.parse( currentUser! )['Token'];

--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -421,6 +421,9 @@
                                   aria-label="anchor" (click)="editDbDetails(database.hierarchy_id);editDbConnectionModal(EditDbCon);"
                                   class="btn btn-icon btn-sm btn-info-light btn-wave waves-effect waves-light">
                                   <i class="ri-edit-line" ngbTooltip="Edit database"></i></button>
+                                <button *ngIf="database.connection_type === 'Integrations' || database.connection_type === 'LLM Integrations'" class="btn btn-icon btn-sm btn-primary-light btn-wave waves-effect waves-light" (click)="smartDashboardFromConnection(database)">
+                                  <i class="fe fe-zap" ngbTooltip="Smart Dashboard"></i>
+                                </button>
                                 <div *ngIf="database?.transformation && !database.is_cross_db" class="d-flex justify-content-end" ngbDropdown>
                                   <button aria-label="Edit Transformation" class="btn btn-icon btn-sm btn-info-light btn-wave waves-effect waves-light" ngbDropdownToggle data-bs-toggle="dropdown">
                                     <i class="ri-edit-line" ngbTooltip="Edit"></i>
@@ -546,6 +549,7 @@
                             <app-insights-button *ngIf="!(database.server_type === 'CSV' || database.server_type ==='EXCEL' || database.server_type ==='SQLITE' || database.server_type ==='QUICKBOOKS' || database.server_type ==='SALESFORCE' || database.server_type ==='GOOGLE_SHEETS' ||database.server_type ==='HUBSPOT')" [buttonName]="' Edit'" [classesList]="'dropdown-item'" [previledgeId]="2" [isBtn]="false"
                               [tabIndex]="0" (btnClickEvent)="editDbDetails(database.hierarchy_id);editDbConnectionModal(EditDbCon);"
                               [faIconList]="'fe fe-edit me-2 d-inline-flex'" [isIcon]="true"></app-insights-button>
+                            <a *ngIf="database.connection_type === 'Integrations' || database.connection_type === 'LLM Integrations'" class="dropdown-item" (click)="smartDashboardFromConnection(database)"><i class='fe fe-zap me-2 d-inline-flex'></i> Smart Dashboard</a>
                             <a *ngIf="database?.transformation && !database.is_cross_db" class="dropdown-item" (click)="goToTransformationLayer(database?.hierarchy_id)" ngbTooltip="Edit Transformation"><img src="./assets/images/icons/transformation_blue.png" class="avatar-databse-sm d-inline-flex me-2"> Edit Transforma...</a>
                             <a *ngIf="(database.server_type === 'CSV' || database.server_type ==='EXCEL')" class="dropdown-item" (click)="fileInput.click()" ><input type="file" (change)="database.server_type === 'CSV' ? uploadfileCsv($event,'replace',database) : uploadfileExcel($event,'replace',database)" [attr.accept]="database.server_type === 'CSV' ? '.csv' : '.xlsx, .xls'" #fileInput style="display: none;" /><i class="fe fe-repeat"></i> Replace</a>
                             <a *ngIf="(database.server_type === 'CSV' || database.server_type ==='EXCEL')" class="dropdown-item" (click)="fileInput.click()"><input type="file" (change)="database.server_type === 'CSV' ? uploadfileCsv($event, 'upsert',database) : uploadfileExcel($event, 'upsert',database)" [attr.accept]="database.server_type === 'CSV' ? '.csv' : '.xlsx, .xls'" #fileInput style="display: none;" /><i class="fe fe-upload"></i> Upsert</a>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -2743,6 +2743,30 @@ connectGoogleSheets(){
       }
     })
   }
+
+  smartDashboardFromConnection(database:any){
+    this.workbechService.createSmartDashboard(database.hierarchy_id).subscribe({
+      next: () => {
+        switch(database.server_type){
+          case 'NINJA':
+            this.templateDashboardService.buildSampleNinjaRMMDashboard(this.container, database.hierarchy_id);
+            break;
+          case 'IMMYBOT':
+            this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id);
+            break;
+          case 'CONNECTWISE':
+            this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, database.hierarchy_id);
+            break;
+          case 'HALOPS':
+            this.templateDashboardService.buildSampleHALOPSADashboard(this.container, database.hierarchy_id);
+            break;
+        }
+      },
+      error: (error) => {
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+      }
+    })
+  }
   gotoDashboardWithoutSwitch(){
     const encodedDashboardId = btoa(this.dashbaordIdToSwitch.toString());
     this.router.navigate(['/analytify/home/sheetsdashboard/',encodedDashboardId])


### PR DESCRIPTION
## Summary
- add API service for creating smart dashboards
- support launching smart dashboard from connection actions
- show Smart Dashboard option for integration-type connections

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68715f8535848320a8b8a8ac856960b3