### PR TITLE
Fix tab background styling

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1672,8 +1672,8 @@
           </div>
           @if(displayTabs){
             <div class="d-flex p-2">
-              <mat-tab-group disableRipple  [selectedIndex]="selectedTabIndex"
-              (selectedTabChange)="selectedSheetTab($event);" 
+              <mat-tab-group disableRipple mat-stretch-tabs [selectedIndex]="selectedTabIndex"
+              (selectedTabChange)="selectedSheetTab($event);"
               >
               <!-- @for(tab of sheetTabs;track tab; let index = $index){ -->
   <!-- <mat-tab data="tab"  [label]="tab.name">

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.scss
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.scss
@@ -560,14 +560,16 @@ tab-label-wrapper {
     opacity: 1;
   }
 }
-// Style mat-tab-label to ensure proper spacing
+// Style mat-tab-label to ensure proper spacing and allow full-width coloring
 ::ng-deep .mat-tab-label {
+  flex: 1 1 auto !important;
   min-width: 120px !important;
-  padding: 0 8px !important;
+  padding: 0 !important;
   height: 48px !important;
 
   .mat-tab-label-content {
     width: 100%;
+    height: 100%;
     position: relative;
   }
 }


### PR DESCRIPTION
## Summary
- ensure tab backgrounds span the entire header area by removing extra padding on `mat-tab-label`
- stretch tab headers using `mat-stretch-tabs`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68765307fde4832096ff6875967416e5