### PR TITLE
Add protected dashboard views

### DIFF
--- a/src/app/components/authentication/protected-home/protected-home.component.html
+++ b/src/app/components/authentication/protected-home/protected-home.component.html
@@ -1,8 +1,79 @@
-<div class="container mt-5">
-  <h3>Protected Dashboards</h3>
-  <ul class="list-group mt-3">
-    <li class="list-group-item" *ngFor="let dash of dashboards" (click)="openDashboard(dash.id)">
-      {{ dash.name || dash.title }}
-    </li>
-  </ul>
+<app-page-header title="Shared Dashboards" moduleId="dashboard" title1="Home" activeitem="Protected"></app-page-header>
+
+<div class="main-container container-fluid TopHeader">
+  <div class="row card-padding-top">
+    <div class="col-sm-12 col-lg-12 col-xl-12 p-0">
+      <div class="d-flex justify-content-between px-5">
+        <div class="connect-txt">
+          <h4 class="card-title mt-2">Dashboards</h4>
+        </div>
+        <div class="new-data-btn d-flex text-align-center">
+          <button *ngIf="gridView" type="button" ngbTooltip="Grid View" class="btn btn-icon btn-outline-primary me-1"><i class="fa fa-th-large"></i></button>
+          <button *ngIf="gridView" type="button" ngbTooltip="Table View" (click)="gridView=false" class="btn btn-icon btn-primary-light me-3"><i class="fa fa-th-list"></i></button>
+          <button *ngIf="!gridView" type="button" ngbTooltip="Grid View" (click)="gridView=true" class="btn btn-icon btn-primary-light me-1"><i class="fa fa-th-large"></i></button>
+          <button *ngIf="!gridView" type="button" ngbTooltip="Table View" class="btn btn-icon btn-outline-primary me-3"><i class="fa fa-th-list"></i></button>
+        </div>
+      </div>
+
+      <div *ngIf="dashboards.length === 0" class="mt-4 px-5">
+        No Dashboards to display!
+      </div>
+
+      <div class="card-body" *ngIf="dashboards.length">
+        <ng-container *ngIf="!gridView; else gridTemplate">
+          <div class="table-responsive table-responsive-height">
+            <table class="table border text-nowrap text-md-nowrap mb-0">
+              <thead class="table-primary bg-primary table-primary-position">
+                <tr>
+                  <th>Title</th>
+                  <th>Created</th>
+                  <th>Last Modified</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr *ngFor="let dashboard of dashboards">
+                  <td>
+                    <div class="d-flex">
+                      <div (click)="openDashboard(dashboard.dashboard_id)" class="imgdf">
+                        <img [src]="dashboard.dashboard_image ? dashboard.dashboard_image : '/assets/images/Db_server_images/smartdashboard.jpg'" alt="" class="w-7 h-7 border rounded-3 me-4 img-cursor">
+                      </div>
+                      <div class="content">
+                        <a class="cursor-pointer" (click)="openDashboard(dashboard.dashboard_id)">{{ dashboard.dashboard_name }}</a>
+                      </div>
+                    </div>
+                  </td>
+                  <td>{{ dashboard.created }}</td>
+                  <td>{{ dashboard.Modified }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </ng-container>
+        <ng-template #gridTemplate>
+          <div class="row">
+            <div *ngFor="let dashboard of dashboards" class="col-md-12 col-xl-3">
+              <div class="card card-box-shadow">
+                <div class="user-image card-box-shadow">
+                  <img [src]="dashboard.dashboard_image ? dashboard.dashboard_image : '/assets/images/Db_server_images/smartdashboard.jpg'" (click)="openDashboard(dashboard.dashboard_id)" alt="" class="card-img-top img-cursor dashboard-user-img-h">
+                </div>
+                <div class="card-body p-1 mt-1 text-center">
+                  <a class="card-title fw-bold d-block" (click)="openDashboard(dashboard.dashboard_id)">{{ dashboard.dashboard_name }}</a>
+                </div>
+                <div class="p-1 text-center">
+                  <div class="row">
+                    <div class="col-md-6"><span class="fw-semibold fs-14">Created on: </span></div>
+                    <div class="col-md-6"><span class="fs-15">{{ dashboard.created }}</span></div>
+                  </div>
+                  <div class="row">
+                    <div class="col-md-6"><span class="fw-semibold fs-14">Modified on: </span></div>
+                    <div class="col-md-6"><span class="fs-15">{{ dashboard.Modified }}</span></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ng-template>
+      </div>
+    </div>
+  </div>
 </div>

--- a/src/app/components/authentication/protected-home/protected-home.component.scss
+++ b/src/app/components/authentication/protected-home/protected-home.component.scss
@@ -1,1 +1,6 @@
-
+.card-box-shadow { box-shadow: 5px 10px 10px 5px #0000001a; }
+.img-cursor { cursor: pointer; }
+.card-padding-top { padding-top: 15px; }
+.table-responsive-height { height: 26rem; }
+.table-primary-position { position: sticky; top: -1px; }
+.dashboard-user-img-h { height: 140px; }

--- a/src/app/components/authentication/protected-home/protected-home.component.ts
+++ b/src/app/components/authentication/protected-home/protected-home.component.ts
@@ -1,17 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router, RouterModule } from '@angular/router';
+import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { SharedModule } from '../../../shared/sharedmodule';
 import { WorkbenchService } from '../../workbench/workbench.service';
 
 @Component({
   selector: 'app-protected-home',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, NgbModule, SharedModule],
   templateUrl: './protected-home.component.html',
   styleUrls: ['./protected-home.component.scss']
 })
 export class ProtectedHomeComponent implements OnInit {
   dashboards: any[] = [];
+  gridView = true;
 
   constructor(private workbenchService: WorkbenchService, private router: Router) {}
 


### PR DESCRIPTION
## Summary
- show shared dashboards with grid/list view toggle
- style protected dashboard page
- use SharedModule and Ngb for UI features

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68773b84ca408320b647f60ee600de84