### PR TITLE
Improve PasskeyLoginComponent visuals

### DIFF
--- a/src/app/components/authentication/passkey-login/passkey-login.component.html
+++ b/src/app/components/authentication/passkey-login/passkey-login.component.html
@@ -24,8 +24,9 @@
             <div class="d-grid mb-3">
               <button class="btn btn-primary" type="submit" [disabled]="emailForm.invalid">Send Recovery Email</button>
             </div>
+            <div class="text-success mt-2" *ngIf="successMessage">{{ successMessage }}</div>
             <div class="text-center">
-              <a class="tx ms-1 text-decoration-underline default-color" (click)="showPasskeyPanel = !showPasskeyPanel">Login with Passkey?</a>
+              <a class="tx ms-1 text-decoration-underline default-color" (click)="togglePasskeyPanel()">Login with Passkey?</a>
             </div>
           </form>
           <form [formGroup]="otpForm" (ngSubmit)="verifyOtp()" *ngIf="showOtp">
@@ -33,6 +34,7 @@
               <label class="mb-2 fw-500">OTP<span class="text-danger ms-1">*</span></label>
               <ng-otp-input [config]="config" (onInputChange)="onOtpChange($event)"></ng-otp-input>
             </div>
+            <div class="text-danger mt-2" *ngIf="errorMessage">{{ errorMessage }}</div>
             <div class="d-grid mb-3">
               <button class="btn btn-primary" type="submit" [disabled]="isLoading || otpForm.invalid">
                 <span *ngIf="isLoading" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
@@ -47,7 +49,7 @@
               <a (click)="showOtp=false" class="tx ms-1 text-decoration-underline default-color">Back</a>
             </div>
           </form>
-          <div *ngIf="showPasskeyPanel" class="mt-3">
+          <div *ngIf="showPasskeyPanel" class="passkey-panel slide-in mt-3">
             <div class="alert alert-secondary">
               Passkey login coming soon.
             </div>

--- a/src/app/components/authentication/passkey-login/passkey-login.component.scss
+++ b/src/app/components/authentication/passkey-login/passkey-login.component.scss
@@ -12,3 +12,22 @@
 .resend-link{
     cursor: pointer;
 }
+
+.passkey-panel {
+    overflow: hidden;
+}
+
+.slide-in {
+    animation: slideIn 0.3s ease-out forwards;
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/src/app/components/authentication/passkey-login/passkey-login.component.ts
+++ b/src/app/components/authentication/passkey-login/passkey-login.component.ts
@@ -31,6 +31,8 @@ export class PasskeyLoginComponent {
   displayTimer = false;
   showPasskeyPanel = false;
   otp: string = '';
+  errorMessage = '';
+  successMessage = '';
 
   constructor(private fb: FormBuilder, private authService: AuthService, private router: Router){
     this.emailForm = this.fb.group({
@@ -71,11 +73,16 @@ export class PasskeyLoginComponent {
   sendRecoveryEmail(){
     if(this.emailForm.invalid){ return; }
     this.authService.sendRecoveryEmail(this.emailForm.value).subscribe({
-      next: ()=>{ 
-        this.showOtp = true; 
+      next: ()=>{
+        this.showOtp = true;
         this.startTimer(1);
+        this.successMessage = 'OTP sent to registered email';
+        this.errorMessage = '';
       },
-      error: ()=>{}
+      error: ()=>{
+        this.errorMessage = 'Failed to send OTP';
+        this.successMessage = '';
+      }
     });
   }
 
@@ -90,11 +97,18 @@ export class PasskeyLoginComponent {
         localStorage.setItem('protected_email', this.emailForm.value.email);
         this.router.navigate(['/protected/home']);
       },
-      error: ()=>{ this.isLoading = false; }
+      error: (err)=>{ 
+        this.isLoading = false; 
+        this.errorMessage = err.error?.message || 'Invalid OTP';
+      }
     });
   }
 
   resendOtpApi(){
     this.sendRecoveryEmail();
+  }
+
+  togglePasskeyPanel(){
+    this.showPasskeyPanel = !this.showPasskeyPanel;
   }
 }


### PR DESCRIPTION
## Summary
- tweak PasskeyLoginComponent layout and UX
- add simple slide‑in panel for passkey login
- show inline success and error messages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68778ebbe464832095af9797ce16dcd0