### PR TITLE
Implement dashboard viewers list

### DIFF
--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.html
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.html
@@ -48,7 +48,7 @@
                             itemsPerPage: itemsPerPage,
                             currentPage: page,
                             totalItems: totalItems
-                          }">
+                          }; let i = index">
                             <td>
                               <div class="d-flex">
                                 <div (click)="viewDashboard(dashboard.server_id,dashboard.queryset_id,dashboard.dashboard_id)" class="imgdf">
@@ -59,6 +59,10 @@
 
                                     (click)="viewDashboard(dashboard.server_id,dashboard.queryset_id,dashboard.dashboard_id)">
                                     {{dashboard.dashboard_name.length > 13 ? (dashboard.dashboard_name | slice:0:15)+'...' : dashboard.dashboard_name }}</a>
+                                  <span class="viewer-icon ms-1" (mouseenter)="hoverIndex=i" (mouseleave)="hoverIndex=null" (click)="openViewerList(dashboard.dashboard_id)">
+                                    <i class="fa fa-eye"></i>
+                                    <span *ngIf="hoverIndex===i" class="badge bg-secondary viewer-badge">{{dashboard.count_of_views}}</span>
+                                  </span>
                                   <p class="mb-0">Created by : {{dashboard.created_by}}</p>
                                 </div>
                               </div>
@@ -98,13 +102,17 @@
                     itemsPerPage: itemsPerPage,
                     currentPage: page,
                     totalItems: totalItems
-                  }" class="col-md-12 col-xl-3">
+                  }; let i = index" class="col-md-12 col-xl-3">
                   <div class="card  ">
                     <div class="user-image card-box-shadow ">                        
                           <img [src]="dashboard.dashboard_image ? dashboard.dashboard_image : '/assets/images/Db_server_images/smartdashboard.jpg'"  (click)="viewDashboard(dashboard.server_id,dashboard.queryset_id,dashboard.dashboard_id)" alt="" class="card-img-top img-cursor dashboard-user-img-h">
                     </div>
                     <div class="card-body p-1 mt-1 text-center">
                         <a  class="card-title fw-bold d-block"  [ngbTooltip]="dashboard.dashboard_name.length > 13 ? dashboard.dashboard_name : null" (click)="viewDashboard(dashboard.server_id,dashboard.queryset_id,dashboard.dashboard_id)"> {{dashboard.dashboard_name.length > 13 ? (dashboard.dashboard_name | slice:0:15)+'...' : dashboard.dashboard_name }}</a>
+                        <span class="viewer-icon ms-1" (mouseenter)="hoverIndex=i" (mouseleave)="hoverIndex=null" (click)="openViewerList(dashboard.dashboard_id)">
+                          <i class="fa fa-eye"></i>
+                          <span *ngIf="hoverIndex===i" class="badge bg-secondary viewer-badge">{{dashboard.count_of_views}}</span>
+                        </span>
                     </div>
                     <div class=" p-1 text-center">
                       <div class="row">
@@ -244,6 +252,24 @@
           Close
         </button>
       </div>
+</ng-template>
+
+<ng-template #viewerListModal let-modal>
+  <div class="modal-header">
+    <h6 class="modal-title">Viewers</h6>
+    <button type="button" class="btn-close" aria-label="Close" (click)="modal.dismiss('Cross click')"></button>
+  </div>
+  <div class="modal-body">
+    <div class="input-group mb-3">
+      <input type="text" class="form-control" placeholder="Search" [(ngModel)]="viewerSearch" (keyup.enter)="searchViewers()">
+      <button class="btn btn-primary" type="button" (click)="searchViewers()"><i class="fe fe-search"></i></button>
+    </div>
+    <div *ngFor="let viewer of viewerList" class="d-flex justify-content-between border-bottom py-1">
+      <span>{{viewer.email}}</span>
+      <i class="fa" [ngClass]="viewer.is_viewed ? 'fa-eye' : 'fa-eye-slash'"></i>
+    </div>
+    <div *ngIf="viewerList.length === 0" class="text-center">No viewers found</div>
+  </div>
 </ng-template>
  
 <ng-template #autorefresh let-modal>

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.scss
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.scss
@@ -15,3 +15,5 @@ a { cursor: pointer;}
 .dashboard-user-img-h { height: 140px;}
 .pagination-count { float: right; font-size: 15px; margin-top: -34px;  }
 .Dashboard-properties-modalpopup{ height: 500px; overflow: scroll;}
+.viewer-icon { position: relative; display: inline-block; cursor: pointer; }
+.viewer-badge { position: absolute; top: -6px; right: -10px; }

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
@@ -47,10 +47,15 @@ export class DashboardPageComponent implements OnInit{
   port:any;
   host:any; 
   @ViewChild('propertiesModal') propertiesModal : any;
+  @ViewChild('viewerListModal') viewerListModal : any;
   frequency : number = 0;
   refreshNow: boolean = false;
   lastRefresh: any;
   nextRefresh: any;
+  viewerList: any[] = [];
+  viewerSearch: string = '';
+  selectedDashboardForViewers: any;
+  hoverIndex: number | null = null;
   
 constructor(private workbechService:WorkbenchService,private router:Router,private templateViewService:ViewTemplateDrivenService,private toasterService:ToastrService,
   private modalService:NgbModal,private toasterservice:ToastrService,private loaderService:LoaderService){
@@ -502,6 +507,28 @@ applyProtectedEmails(){
     next: ()=>{ this.toasterservice.success('Emails Saved','success'); },
     error: ()=>{}
   });
+}
+
+openViewerList(dashboardId: any){
+  this.selectedDashboardForViewers = dashboardId;
+  this.viewerSearch = '';
+  this.getDashboardViewers();
+  this.modalService.open(this.viewerListModal, { centered: true });
+}
+
+getDashboardViewers(search?: string){
+  const obj: any = { dashboard_id: this.selectedDashboardForViewers };
+  if(search){
+    obj.search = search;
+  }
+  this.workbechService.getDashboardViewers(obj).subscribe({
+    next: (data) => { this.viewerList = data?.sheets || []; },
+    error: () => { this.viewerList = []; }
+  });
+}
+
+searchViewers(){
+  this.getDashboardViewers(this.viewerSearch);
 }
 
 

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1315,4 +1315,13 @@ deleteUser(id:any){
       { headers }
     );
   }
+
+  getDashboardViewers(obj: any){
+    const currentUser = localStorage.getItem('currentUser');
+    this.accessToken = JSON.parse(currentUser!)['Token'];
+    return this.http.post<any>(
+      `http://127.0.0.1:8000/v1/list_of_shared_users/${this.accessToken}`,
+      obj
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add API call for fetching dashboard viewers
- show viewer eye icon on dashboard list
- allow searching viewers via new modal
- style viewer count badge

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877aab14268832094e569516f30be80