### PR TITLE
Add reminder bell in viewers modal

### DIFF
--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.html
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.html
@@ -266,7 +266,10 @@
     </div>
     <div *ngFor="let viewer of viewerList" class="d-flex justify-content-between border-bottom py-1">
       <span>{{viewer.email}}</span>
-      <i class="fa" [ngClass]="viewer.is_viewed ? 'fa-eye' : 'fa-eye-slash'"></i>
+      <span>
+        <i class="fa me-2" [ngClass]="viewer.is_viewed ? 'fa-eye' : 'fa-eye-slash'"></i>
+        <i class="fa fa-bell cursor-pointer" (click)="sendReminder(viewer.email)"></i>
+      </span>
     </div>
     <div *ngIf="viewerList.length === 0" class="text-center">No viewers found</div>
   </div>

--- a/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
+++ b/src/app/components/workbench/dashboard-page/dashboard-page.component.ts
@@ -531,5 +531,17 @@ searchViewers(){
   this.getDashboardViewers(this.viewerSearch);
 }
 
+sendReminder(email: string){
+  const obj = {
+    dashboard_id: this.selectedDashboardForViewers,
+    encrypted_dashboard_id: btoa(String(this.selectedDashboardForViewers)),
+    email
+  };
+  this.workbechService.sendEmailReminder(obj).subscribe({
+    next: () => this.toasterservice.success(`Reminder set for ${email}`,'success'),
+    error: () => this.toasterservice.error('Failed to set reminder','error')
+  });
+}
+
 
 }

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1324,4 +1324,11 @@ deleteUser(id:any){
       obj
     );
   }
+
+  sendEmailReminder(obj: any){
+    return this.http.post<any>(
+      'http://127.0.0.1:8000/v1/email_remainder/wLP4ie8GOyGfX8o19ETTSrWqoNpR0E',
+      obj
+    );
+  }
 }


### PR DESCRIPTION
## Summary
- add API call to send dashboard reminder emails
- wire up reminder action in dashboard viewer modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877ade92e08832082d0f4c9431a5975