### PR TITLE
Fix protected dashboard scenario handling

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import { authen } from './shared/routes/authenticationroutes';
 // import { landing } from './shared/routes/landingroutes';
 import { workbench } from './shared/routes/workbenckroutes';
 import { WorkbenchLayoutsComponent } from './shared/layout-components/layouts/workbench-layouts/workbench-layouts.component';
+import { authGuard } from './auth.guard';
 export const App_Route: Route[] = [
       { path: '', redirectTo: 'authentication/login', pathMatch: 'full' },
       {
@@ -26,8 +27,14 @@ export const App_Route: Route[] = [
       },
       {
         path: 'dashboard/share/protected/:id1',
-        loadComponent: () =>
-          import('../app/components/workbench/sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
+        component: WorkbenchLayoutsComponent,
+        children: [
+          {
+            path: '',
+            loadComponent: () =>
+              import('../app/components/workbench/sheetsdashboard/sheetsdashboard.component').then((m) => m.SheetsdashboardComponent),
+          },
+        ],
       },
       {
         path: 'protected/home',
@@ -62,3 +69,4 @@ export const App_Route: Route[] = [
 
 
     ]
+

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -12,7 +12,7 @@
 
     <app-page-header (btnClickEvent)="toggleSidebar()" title="{{dashboardTagName}}" title1="public" [isPublicUrl]="false" activeitem="Dashboard"></app-page-header>
     </div>
-  <div *ngIf="isProtectedUrl && hasProtectedAccess" class="p-2">
+  <div *ngIf="isProtectedUrl && hasProtectedAccess && !isAuthenticated" class="p-2">
     <button class="btn btn-link" (click)="goBackToProtectedHome()">Back to Dashboards</button>
   </div>
   <!-- <div *ngIf="publicHeader">

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -198,6 +198,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   isProtectedUrl = false;
   isProtectedValidated = false;
   hasProtectedAccess = false;
+  isAuthenticated = false;
   encryptedEmail: string | null = null;
   passkey: string = '';
   @ViewChild('passkeyModal') passkeyModal:any;
@@ -257,7 +258,8 @@ export class SheetsdashboardComponent implements OnDestroy {
     private loaderService:LoaderService,private modalService:NgbModal, private viewTemplateService:ViewTemplateDrivenService,private toasterService:ToastrService,
      private sanitizer: DomSanitizer,private cdr: ChangeDetectorRef, private http: HttpClient,private sharedService:SharedService,private cd:ChangeDetectorRef){
     this.dashboard = [];
-    const currentUrl = this.router.url; 
+    this.isAuthenticated = !!localStorage.getItem('currentUser');
+    const currentUrl = this.router.url;
     this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
       echarts.registerMap('world', geoJson); 
     });
@@ -265,17 +267,18 @@ export class SheetsdashboardComponent implements OnDestroy {
       this.updateDashbpardBoolen= true;
       this.isPublicUrl = true;
       this.active = 2;
-      this.publicHeader = true
+      this.publicHeader = true;
       if (route.snapshot.params['id1']) {
       this.dashboardId = +atob(route.snapshot.params['id1'])
       }
     }
     if(currentUrl.includes('dashboard/share/protected')){
       this.updateDashbpardBoolen= true;
-      this.isPublicUrl = true;
       this.isProtectedUrl = true;
+      // protected dashboards always use public APIs
+      this.isPublicUrl = true;
       this.active = 2;
-      this.publicHeader = true;
+      this.publicHeader = !this.isAuthenticated;
       if (route.snapshot.params['id1']) {
         this.dashboardId = +atob(route.snapshot.params['id1']);
       }
@@ -574,7 +577,7 @@ export class SheetsdashboardComponent implements OnDestroy {
 
   ngOnInit() {
     this.hasProtectedAccess = localStorage.getItem('protected_access') === 'true';
-    if(this.hasProtectedAccess){
+    if(this.hasProtectedAccess || this.isAuthenticated){
       this.isProtectedValidated = true;
     }
     let displayGrid = DisplayGrid.Always;
@@ -617,7 +620,7 @@ export class SheetsdashboardComponent implements OnDestroy {
     };
     if(this.dashboardToken){
       this.fetchDashboardIdFromToken();
-    } else if(!this.isPublicUrl){
+    } else if(!this.isPublicUrl && !this.isProtectedUrl){
       this.initialiserMethods();
     }
     //this.getSheetData();
@@ -3027,7 +3030,7 @@ arraysHaveSameData(arr1: number[], arr2: number[]): boolean {
       console.error('Gridster element not found!');
     }
     if(this.isProtectedUrl){
-      if(this.isProtectedValidated){
+      if(this.isProtectedValidated || !this.encryptedEmail){
         this.loadProtectedDashboard();
       } else {
         this.modalService.open(this.passkeyModal,{backdrop:'static', centered:true});

--- a/src/app/shared/layout-components/layouts/workbench-layouts/workbench-layouts.component.html
+++ b/src/app/shared/layout-components/layouts/workbench-layouts/workbench-layouts.component.html
@@ -1,17 +1,17 @@
 
-<app-switcher></app-switcher>
+<app-switcher *ngIf="!hideLayout"></app-switcher>
 <div class="page">
     <div class="page-main">
-        <app-header></app-header>
-        <app-sidebar appHoverEffectSidebar></app-sidebar>
+        <app-header *ngIf="!hideLayout"></app-header>
+        <app-sidebar *ngIf="!hideLayout" appHoverEffectSidebar></app-sidebar>
         <div class="main-content app-content mt-0"  (click)="togglesidemenuBody()">
 
                 <router-outlet></router-outlet>
-            
-            
+
+
         </div>
     </div>
     <!-- <app-footer></app-footer> -->
-<app-tab-to-top></app-tab-to-top>
+<app-tab-to-top *ngIf="!hideLayout"></app-tab-to-top>
 </div>
 <div id="responsive-overlay" (click)="clearToggle()"></div>

--- a/src/app/shared/layout-components/layouts/workbench-layouts/workbench-layouts.component.ts
+++ b/src/app/shared/layout-components/layouts/workbench-layouts/workbench-layouts.component.ts
@@ -16,16 +16,21 @@ export class WorkbenchLayoutsComponent {
   currentRoute:  string | undefined;
   urlData:  string[] | undefined;
   document: any;
+  isAuthenticated = false;
+  hideLayout = false;
  constructor(
-  private router:Router, 
+  private router:Router,
    public navServices: NavService,
    private elementRef: ElementRef,
    private renderer: Renderer2,
  ) {
   this.router.events.pipe(
     filter(event => event instanceof NavigationEnd)
-  ).subscribe(() => {
+  ).subscribe((event: NavigationEnd) => {
     window.scrollTo(0, 0);
+    this.isAuthenticated = !!localStorage.getItem('currentUser');
+    const url = (event as NavigationEnd).urlAfterRedirects;
+    this.hideLayout = url.startsWith('/dashboard/share/protected') && !this.isAuthenticated;
   });
   document.body.classList.remove( 'landing-page','ltr');
   // document.body.classList.add('sidebar-mini');


### PR DESCRIPTION
## Summary
- wrap protected dashboard in layout without auth guard
- hide layout elements on shared dashboard when user isn't logged in
- keep calling public API via `isPublicUrl`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687881b6bc948320b679702de47d5694