### PR TITLE
Add Shopify smart dashboard flow

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1017,6 +1017,12 @@ deleteUser(id:any){
       return this.http.get<any>(`${environment.apiUrl}/halops_dashboard/`+id+'/'+this.accessToken);
     }
 
+    buildSampleShopifyDashbaord(id: number){
+      const currentUser = localStorage.getItem( 'currentUser' );
+      this.accessToken = JSON.parse( currentUser! )['Token'];
+      return this.http.get<any>(`${environment.apiUrl}/shopify_dashbaord/`+id+'/'+this.accessToken);
+    }
+
     buildQuickBooksDashbaord(id : number){
       const currentUser = localStorage.getItem( 'currentUser' );
       this.accessToken = JSON.parse( currentUser! )['Token'];

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -1281,12 +1281,30 @@ export class WorkbenchComponent implements OnInit{
               this.openShopifyForm = false;
               }
               const encodedId = btoa(this.databaseId.toString());
-              // this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
               if(this.iscrossDbSelect){
                 this.selectedHirchyIdCrsDb = this.databaseId
                 this.connectCrossDbs();
+              }else if(this.datasourceSwitchUI){
+                this.switchDatabase();
               }else{
-              this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+                Swal.fire({
+                  position: "center",
+                  iconHtml: '<img src="./assets/images/copilot.gif">',
+                  title: "Generate an <b>AI Adoption Dashboard</b> from your data with just one click?",
+                  showConfirmButton: true,
+                  showCancelButton: true,
+                  confirmButtonText: 'Yes',
+                  cancelButtonText: 'Skip',
+                  customClass: {
+                    icon: 'no-icon-bg',
+                  }
+                }).then((result) => {
+                  if (result.isConfirmed) {
+                    this.templateDashboardService.buildSampleShopifyDashboard(this.container, this.databaseId);
+                  } else {
+                    this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+                  }
+                });
               }
             }
           },

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -1066,6 +1066,40 @@ buildSampleTallyDashboard(container: ViewContainerRef, databaseId: any) {
     }
   )
 }
+
+buildSampleShopifyDashboard(container: ViewContainerRef, databaseId: any) {
+  const componentRef = container.createComponent(InsightEchartComponent);
+  this.echartInstance = componentRef.instance;
+  this.workbechService.buildSampleShopifyDashbaord(databaseId).subscribe({next: (responce) => {
+    const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+    queries.forEach((query: any) => {
+      const obj ={
+        query_set_id:query.queryset_id,
+        hierarchy_id:query.hierarchy_id,
+        joining_tables: query.joining_tables,
+        join_type:query.join_type,
+        joining_conditions:query.joining_conditions,
+        dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}}
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({next: (res) => {
+          // this.buildDashboardResponseData(res);
+          },
+          error: (error) => {
+            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+            console.log(error);
+          }
+        }
+      )
+    });
+    this.buildDashboardResponseData(responce);
+      },
+      error: (error) => {
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+        console.log(error);
+      }
+    }
+  )
+}
 buildSampleHubspotDashboard(container: ViewContainerRef, databaseId: any) {
   const componentRef = container.createComponent(InsightEchartComponent);
   this.echartInstance = componentRef.instance;


### PR DESCRIPTION
## Summary
- add API call to create Shopify dashboard in workbench service
- build dashboard scaffolding in template service
- generate Shopify dashboard after connecting a store

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878a19bfafc8320aa82fcbe5e1b0e91