### PR TITLE
Fix protected dashboard layout

### DIFF
--- a/src/app/components/authentication/protected-dashboards/protected-dashboards.component.ts
+++ b/src/app/components/authentication/protected-dashboards/protected-dashboards.component.ts
@@ -33,6 +33,13 @@ export class ProtectedDashboardsComponent implements OnInit {
 
   openDashboard(id: number): void {
     const encoded = btoa(id.toString());
-    this.router.navigate(['/dashboard/share/protected', encoded]);
+    const isAuthenticated = !!localStorage.getItem('currentUser');
+    if (isAuthenticated) {
+      this.router.navigate(['/analytify/home/sheetsdashboard', encoded], {
+        queryParams: { protected: true }
+      });
+    } else {
+      this.router.navigate(['/dashboard/share/protected', encoded]);
+    }
   }
 }

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -8,11 +8,11 @@
   <app-page-header title="Dashboard" moduleId="dashboard" title1="Home" [multiLevel]="true" title2="sheets" title2Route="/analytify/sheets" activeitem="Dashboard"></app-page-header>
   </div> -->
   
-  <div *ngIf="isPublicUrl">
+  <div *ngIf="isPublicUrl && !isAuthenticated">
 
     <app-page-header (btnClickEvent)="toggleSidebar()" title="{{dashboardTagName}}" title1="public" [isPublicUrl]="false" activeitem="Dashboard"></app-page-header>
     </div>
-  <div *ngIf="isProtectedUrl && hasProtectedAccess && !isAuthenticated" class="p-2">
+  <div *ngIf="isProtectedUrl && hasProtectedAccess && !isAuthenticated && !protectedQuery" class="p-2">
     <button class="btn btn-link" (click)="goBackToProtectedHome()">Back to Dashboards</button>
   </div>
   <!-- <div *ngIf="publicHeader">

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -199,6 +199,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   isProtectedValidated = false;
   hasProtectedAccess = false;
   isAuthenticated = false;
+  protectedQuery = false;
   encryptedEmail: string | null = null;
   passkey: string = '';
   @ViewChild('passkeyModal') passkeyModal:any;
@@ -302,8 +303,18 @@ export class SheetsdashboardComponent implements OnDestroy {
     //     }
     // }
     else if(currentUrl.includes('analytify/home/sheetsdashboard')){
-      this.dashboardView = true;
-      this.updateDashbpardBoolen= true
+      this.updateDashbpardBoolen = true;
+      const isProtected = this.route.snapshot.queryParamMap.get('protected') === 'true';
+      this.protectedQuery = isProtected;
+      if (isProtected) {
+        this.isProtectedUrl = true;
+        this.isPublicUrl = true;
+        this.active = 2;
+        this.publicHeader = false;
+      } else {
+        this.dashboardView = true;
+        this.publicHeader = false;
+      }
       if (route.snapshot.params['id3']) {
         // this.databaseId = +atob(route.snapshot.params['id1']);
         // this.qrySetId = +atob(route.snapshot.params['id2'])
@@ -318,7 +329,7 @@ export class SheetsdashboardComponent implements OnDestroy {
         const dbcopy = navigation?.extras?.state?.['dbCopy'] ?? history.state?.['dbCopy'];
         if(dbcopy){
           this.toasterService.success('Dashboard Copied Successfully.','success',{ positionClass: 'toast-top-right'})
-        }else if (dbSwitched) {
+        }else if (dbSwitched && !isProtected) {
           this.getSavedDashboardData();
            setTimeout(() => {
             this.refreshDashboard(true);  // might run before API completes!
@@ -576,6 +587,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   }
 
   ngOnInit() {
+    this.isAuthenticated = !!localStorage.getItem('currentUser');
     this.hasProtectedAccess = localStorage.getItem('protected_access') === 'true';
     if(this.hasProtectedAccess || this.isAuthenticated){
       this.isProtectedValidated = true;


### PR DESCRIPTION
## Summary
- ensure public header hidden for authenticated users viewing protected dashboards
- show "Back to Dashboards" only for guest users with passkey

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878a6bb815c832080d8538173ffc0b6