### PR TITLE
Fix duplicate API calls in smart dashboard creation

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -2746,19 +2746,19 @@ connectGoogleSheets(){
 
   smartDashboardFromConnection(database:any){
     this.workbechService.createSmartDashboard(database.hierarchy_id).subscribe({
-      next: () => {
+      next: (res) => {
         switch(database.server_type){
           case 'NINJA':
-            this.templateDashboardService.buildSampleNinjaRMMDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleNinjaRMMDashboard(this.container, database.hierarchy_id, res);
             break;
           case 'IMMYBOT':
-            this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id, res);
             break;
           case 'CONNECTWISE':
-            this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, database.hierarchy_id, res);
             break;
           case 'HALOPS':
-            this.templateDashboardService.buildSampleHALOPSADashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleHALOPSADashboard(this.container, database.hierarchy_id, res);
             break;
         }
       },

--- a/src/app/services/template-dashboard.service.spec.ts
+++ b/src/app/services/template-dashboard.service.spec.ts
@@ -1,16 +1,42 @@
 import { TestBed } from '@angular/core/testing';
-
+import { of } from 'rxjs';
 import { TemplateDashboardService } from './template-dashboard.service';
+import { WorkbenchService } from '../components/workbench/workbench.service';
+import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
 
-describe('TemplateDashboardService', () => {
+describe('TemplateDashboardService buildSampleNinjaRMMDashboard', () => {
   let service: TemplateDashboardService;
+  let workbenchServiceSpy: jasmine.SpyObj<WorkbenchService>;
+  const routerSpy = {} as Router;
+  const toastrSpy = { error: () => {} } as ToastrService;
+  const containerStub = { createComponent: () => ({ instance: {} }) } as any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    workbenchServiceSpy = jasmine.createSpyObj('WorkbenchService', ['buildSampleNinjaRMMDashboard', 'joiningTablesTest']);
+    workbenchServiceSpy.joiningTablesTest.and.returnValue(of({ sheets: [] }));
+
+    TestBed.configureTestingModule({
+      providers: [
+        TemplateDashboardService,
+        { provide: WorkbenchService, useValue: workbenchServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: ToastrService, useValue: toastrSpy }
+      ]
+    });
+
     service = TestBed.inject(TemplateDashboardService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('uses provided response without calling service', () => {
+    const res = { datasource_query: {}, sheets: [] } as any;
+    service.buildSampleNinjaRMMDashboard(containerStub, 1, res);
+    expect(workbenchServiceSpy.buildSampleNinjaRMMDashboard).not.toHaveBeenCalled();
+  });
+
+  it('calls service when response not provided', () => {
+    workbenchServiceSpy.buildSampleNinjaRMMDashboard.and.returnValue(of({ datasource_query: {}, sheets: [] }));
+    service.buildSampleNinjaRMMDashboard(containerStub, 1);
+    expect(workbenchServiceSpy.buildSampleNinjaRMMDashboard).toHaveBeenCalledWith(1);
   });
 });

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -480,128 +480,202 @@ export class TemplateDashboardService {
     return data;
   }
 
-  buildSampleConnectWiseDashboard(container: ViewContainerRef, databaseId : any){
-    const componentRef =container.createComponent(InsightEchartComponent);
+  buildSampleConnectWiseDashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
+    const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleDashbaord(databaseId).subscribe({next: (responce) => {
-      const obj ={
-        query_set_id:responce.datasource_query.queryset_id,
-        hierarchy_id:responce.datasource_query.hierarchy_id,
-        joining_tables: responce.datasource_query.joining_tables,
-        join_type:responce.datasource_query.join_type,
-        joining_conditions:responce.datasource_query.joining_conditions,
-        dragged_array: {dragged_array:responce.datasource_query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-      
-        this.buildDashboardResponseData(responce,"connectWise");
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-            console.log(error);
-          }
-        }
-      )
-      this.buildDashboardResponseData(responce,"connectWise");
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'connectWise');
         },
         error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
           console.log(error);
-        }
-      }
-    )
+        },
+      });
+
+      this.buildDashboardResponseData(res, 'connectWise');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService.buildSampleDashbaord(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+    }
   }
 
-  buildSampleQuickbooksDashboard(container: ViewContainerRef, databaseId : any){
-    const componentRef =container.createComponent(InsightEchartComponent);
+  buildSampleQuickbooksDashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
+    const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildQuickBooksDashbaord(databaseId).subscribe({next: (responce) => {
-      const obj ={
-        query_set_id:responce.datasource_query.queryset_id,
-        hierarchy_id:responce.datasource_query.hierarchy_id,
-        joining_tables: responce.datasource_query.joining_tables,
-        join_type:responce.datasource_query.join_type,
-        joining_conditions:responce.datasource_query.joining_conditions,
-        dragged_array: {dragged_array:responce.datasource_query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-      
-        this.buildDashboardResponseData(responce,'quickbooks');
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-            console.log(error);
-          }
-        }
-      )
-      this.buildDashboardResponseData(responce,'quickbooks');
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'quickbooks');
         },
         error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
           console.log(error);
-        }
-      }
-    )
+        },
+      });
+
+      this.buildDashboardResponseData(res, 'quickbooks');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService.buildQuickBooksDashbaord(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+    }
   }
-  buildSampleImmybotDashboard(container: ViewContainerRef, databaseId: any) {
+  buildSampleImmybotDashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
     const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleImmybotDashboard(databaseId).subscribe({
-      next: (responce:any) => {
-        const obj = {
-          query_set_id: responce.datasource_query.queryset_id,
-          hierarchy_id: responce.datasource_query.hierarchy_id,
-          joining_tables: responce.datasource_query.joining_tables,
-          join_type: responce.datasource_query.join_type,
-          joining_conditions: responce.datasource_query.joining_conditions,
-          dragged_array: { dragged_array: responce.datasource_query.dragged_array, dragged_array_indexing: {} },
-        } as any;
-        this.workbechService.joiningTablesTest(obj).subscribe({
-          next: (res) => {
-            this.buildDashboardResponseData(res, 'immybot');
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-            console.log(error);
-          }
-        });
-        this.buildDashboardResponseData(responce, 'immybot');
-      },
-      error: (error:any) => {
-        this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-        console.log(error);
-      }
-    });
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'immybot');
+        },
+        error: (error) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+      this.buildDashboardResponseData(res, 'immybot');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService.buildSampleImmybotDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error: any) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+    }
   }
-  buildSampleNinjaRMMDashboard(container: ViewContainerRef, databaseId: any) {
+  buildSampleNinjaRMMDashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
     const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleNinjaRMMDashboard(databaseId).subscribe({
-      next: (responce: any) => {
-        const obj = {
-          query_set_id: responce.datasource_query.queryset_id,
-          hierarchy_id: responce.datasource_query.hierarchy_id,
-          joining_tables: responce.datasource_query.joining_tables,
-          join_type: responce.datasource_query.join_type,
-          joining_conditions: responce.datasource_query.joining_conditions,
-          dragged_array: { dragged_array: responce.datasource_query.dragged_array, dragged_array_indexing: {} },
-        } as any;
-        this.workbechService.joiningTablesTest(obj).subscribe({
-          next: (res) => {
-            this.buildDashboardResponseData(res, 'ninjarmm');
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-            console.log(error);
-          }
-        });
-        this.buildDashboardResponseData(responce, 'ninjarmm');
-      },
-      error: (error: any) => {
-        this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-        console.log(error);
-      }
-    });
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'ninjarmm');
+        },
+        error: (error) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+      this.buildDashboardResponseData(res, 'ninjarmm');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService.buildSampleNinjaRMMDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error: any) => {
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
+          console.log(error);
+        },
+      });
+    }
   }
   buildDashboardResponseData(responce: any,formType: string){
     let dashboardData: any[] = [];
@@ -969,65 +1043,103 @@ export class TemplateDashboardService {
   }
 
   
-  buildSampleHALOPSADashboard(container: ViewContainerRef , databaseId: any){
-    const componentRef =container.createComponent(InsightEchartComponent);
+  buildSampleHALOPSADashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
+    const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleHALOPSADashbaord(databaseId).subscribe({next: (responce) => {
-      const obj ={
-        query_set_id:responce.datasource_query.queryset_id,
-        hierarchy_id:responce.datasource_query.hierarchy_id,
-        joining_tables: responce.datasource_query.joining_tables,
-        join_type:responce.datasource_query.join_type,
-        joining_conditions:responce.datasource_query.joining_conditions,
-        dragged_array: {dragged_array:responce.datasource_query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {        
-      this.buildDashboardResponseData(responce,'HALOPSA');      
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'HALOPSA');
         },
         error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
           console.log(error);
-        }
-      }
-    )
-    this.buildDashboardResponseData(responce,'HALOPSA');
         },
+      });
+      this.buildDashboardResponseData(res, 'HALOPSA');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService.buildSampleHALOPSADashbaord(databaseId).subscribe({
+        next: handleResponse,
         error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
           console.log(error);
-        }
-      }
-    )
+        },
+      });
+    }
   }
-  buildSampleSalesforceDashboard(container: ViewContainerRef , databaseId: any){
-    const componentRef =container.createComponent(InsightEchartComponent);
+  buildSampleSalesforceDashboard(
+    container: ViewContainerRef,
+    databaseId: any,
+    responce?: any
+  ) {
+    const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleSalesforceDashbaord(databaseId).subscribe({next: (responce) => {
-      const obj ={
-        query_set_id:responce.datasource_query.queryset_id,
-        hierarchy_id:responce.datasource_query.hierarchy_id,
-        joining_tables: responce.datasource_query.joining_tables,
-        join_type:responce.datasource_query.join_type,
-        joining_conditions:responce.datasource_query.joining_conditions,
-        dragged_array: {dragged_array:responce.datasource_query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-      this.buildDashboardResponseData(responce,'salesforce');      
+
+    const handleResponse = (res: any) => {
+      const obj = {
+        query_set_id: res.datasource_query.queryset_id,
+        hierarchy_id: res.datasource_query.hierarchy_id,
+        joining_tables: res.datasource_query.joining_tables,
+        join_type: res.datasource_query.join_type,
+        joining_conditions: res.datasource_query.joining_conditions,
+        dragged_array: {
+          dragged_array: res.datasource_query.dragged_array,
+          dragged_array_indexing: {},
+        },
+      } as any;
+      this.workbechService.joiningTablesTest(obj).subscribe({
+        next: (joinRes) => {
+          this.buildDashboardResponseData(joinRes, 'salesforce');
         },
         error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          this.toasterservice.error(error.error.message, 'error', {
+            positionClass: 'toast-center-center',
+          });
           console.log(error);
-        }
-      }
-    )
-    this.buildDashboardResponseData(responce,'salesforce');
         },
-        error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-          console.log(error);
-        }
-      }
-    )
+      });
+      this.buildDashboardResponseData(res, 'salesforce');
+    };
+
+    if (responce) {
+      handleResponse(responce);
+    } else {
+      this.workbechService
+        .buildSampleSalesforceDashbaord(databaseId)
+        .subscribe({
+          next: handleResponse,
+          error: (error) => {
+            this.toasterservice.error(error.error.message, 'error', {
+              positionClass: 'toast-center-center',
+            });
+            console.log(error);
+          },
+        });
+    }
   }
   private readonly KPI_MAX       = 8;
   private readonly KPI_PER_ROW   = 8;


### PR DESCRIPTION
## Summary
- update `smartDashboardFromConnection` to reuse existing response
- refactor sample dashboard builder methods to accept optional response data
- adjust template-dashboard service unit test for new behaviour

## Testing
- `npm test --silent -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878dc4f0a948320a0600cebe4c77e4e