### PR TITLE
Fix duplicate API call in smart dashboard creation

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -2940,34 +2940,34 @@ connectGoogleSheets(){
 
   smartDashboardFromConnection(database:any){
     this.workbechService.createSmartDashboard(database.hierarchy_id).subscribe({
-      next: () => {
+      next: (responce) => {
         switch(database.server_type){
           case 'TALLY':
-            this.templateDashboardService.buildSampleTallyDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleTallyDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'SALESFORCE':
-            this.templateDashboardService.buildSampleSalesforceDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleSalesforceDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'QUICKBOOKS':
-            this.templateDashboardService.buildSampleQuickbooksDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleQuickbooksDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'IMMYBOT':
-            this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id, responce);
             break;
             case 'NINJA':
-            this.templateDashboardService.buildSampleNinjaRMMDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleNinjaRMMDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'HUBSPOT':
-            this.templateDashboardService.buildSampleHubspotDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleHubspotDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'CONNECTWISE':
-            this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'HALOPS':
-            this.templateDashboardService.buildSampleHALOPSADashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleHALOPSADashboard(this.container, database.hierarchy_id, responce);
             break;
             case 'OPEN_AI':
-            this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id);
+            this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
             break;
         }
       },

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -481,10 +481,11 @@ export class TemplateDashboardService {
     return data;
   }
 
-  buildSampleConnectWiseDashboard(container: ViewContainerRef, databaseId : any){
+  buildSampleConnectWiseDashboard(container: ViewContainerRef, databaseId : any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleDashbaord(databaseId).subscribe({next: (responce) => {
+
+    const handleResponse = (responce: any) => {
       const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
       queries.forEach((query: any) => {
         const obj = {
@@ -495,9 +496,7 @@ export class TemplateDashboardService {
           joining_conditions: query.joining_conditions,
           dragged_array: {dragged_array: query.dragged_array, dragged_array_indexing:{}},
         } as any;
-        this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-            // this.buildDashboardResponseData(responce);
-          },
+        this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
           error: (error) => {
             this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
             console.log(error);
@@ -505,19 +504,26 @@ export class TemplateDashboardService {
         });
       });
       this.buildDashboardResponseData(responce);
-        },
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleDashbaord(databaseId).subscribe({
+        next: handleResponse,
         error: (error) => {
           this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
           console.log(error);
         }
-      }
-    )
+      });
+    }
   }
 
-  buildSampleQuickbooksDashboard(container: ViewContainerRef, databaseId : any){
+  buildSampleQuickbooksDashboard(container: ViewContainerRef, databaseId : any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildQuickBooksDashbaord(databaseId).subscribe({next: (responce) => {
+
+    const handleResponse = (responce: any) => {
       const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
       queries.forEach((query: any) => {
         const obj ={
@@ -528,91 +534,103 @@ export class TemplateDashboardService {
           joining_conditions:query.joining_conditions,
           dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
         } as any
-        this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-
-          // this.buildDashboardResponseData(responce);
-            },
+        this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
             error: (error) => {
               this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
               console.log(error);
             }
-          }
-        )
+          })
       });
       this.buildDashboardResponseData(responce);
-        },
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildQuickBooksDashbaord(databaseId).subscribe({
+        next: handleResponse,
         error: (error) => {
           this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
           console.log(error);
         }
-      }
-    )
+      })
+    }
   }
-  buildSampleImmybotDashboard(container: ViewContainerRef, databaseId: any) {
+  buildSampleImmybotDashboard(container: ViewContainerRef, databaseId: any, responceData?: any) {
     const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleImmybotDashboard(databaseId).subscribe({
-      next: (responce:any) => {
-        const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
-        queries.forEach((query: any) => {
-          const obj = {
-            query_set_id: query.queryset_id,
-            hierarchy_id: query.hierarchy_id,
+
+    const handleResponse = (responce:any) => {
+      const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+      queries.forEach((query: any) => {
+        const obj = {
+          query_set_id: query.queryset_id,
+          hierarchy_id: query.hierarchy_id,
             joining_tables: query.joining_tables,
             join_type: query.join_type,
             joining_conditions: query.joining_conditions,
             dragged_array: { dragged_array: query.dragged_array, dragged_array_indexing: {} },
           } as any;
           this.workbechService.joiningTablesTest(obj).subscribe({
-            next: (res) => {
-              // this.buildDashboardResponseData(res);
-            },
+            next: () => {},
             error: (error) => {
               this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
               console.log(error);
             }
           });
-        });
-        this.buildDashboardResponseData(responce);
-      },
-      error: (error:any) => {
-        this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-        console.log(error);
-      }
-    });
+      });
+      this.buildDashboardResponseData(responce);
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleImmybotDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error:any) => {
+          this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
+          console.log(error);
+        }
+      });
+    }
   }
-  buildSampleNinjaRMMDashboard(container: ViewContainerRef, databaseId: any) {
+  buildSampleNinjaRMMDashboard(container: ViewContainerRef, databaseId: any, responceData?: any) {
     const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleNinjaRMMDashboard(databaseId).subscribe({
-      next: (responce: any) => {
-        const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
-        queries.forEach((query: any) => {
-          const obj = {
-            query_set_id: query.queryset_id,
-            hierarchy_id: query.hierarchy_id,
+
+    const handleResponse = (responce: any) => {
+      const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+      queries.forEach((query: any) => {
+        const obj = {
+          query_set_id: query.queryset_id,
+          hierarchy_id: query.hierarchy_id,
             joining_tables: query.joining_tables,
             join_type: query.join_type,
             joining_conditions: query.joining_conditions,
             dragged_array: { dragged_array: query.dragged_array, dragged_array_indexing: {} },
           } as any;
           this.workbechService.joiningTablesTest(obj).subscribe({
-            next: (res) => {
-              // this.buildDashboardResponseData(res);
-            },
+            next: () => {},
             error: (error) => {
               this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
               console.log(error);
             }
           });
-        });
-        this.buildDashboardResponseData(responce);
-      },
-      error: (error: any) => {
-        this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
-        console.log(error);
-      }
-    });
+      });
+      this.buildDashboardResponseData(responce);
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleNinjaRMMDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error: any) => {
+          this.toasterservice.error(error.error.message, 'error', { positionClass: 'toast-center-center' });
+          console.log(error);
+        }
+      });
+    }
   }
   buildDashboardResponseData(responce: any){
     let dashboardData: any[] = [];
@@ -933,10 +951,11 @@ export class TemplateDashboardService {
   }
 
   
-  buildSampleHALOPSADashboard(container: ViewContainerRef , databaseId: any){
+  buildSampleHALOPSADashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleHALOPSADashbaord(databaseId).subscribe({next: (responce) => {
+
+    const handleResponse = (responce: any) => {
       const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
       queries.forEach((query: any) => {
         const obj ={
@@ -947,29 +966,34 @@ export class TemplateDashboardService {
           joining_conditions:query.joining_conditions,
           dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
         } as any;
-        this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-          // this.buildDashboardResponseData(responce);
-            },
-            error: (error) => {
-              this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-              console.log(error);
+          this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
+              error: (error) => {
+                this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+                console.log(error);
+              }
             }
-          }
-        )
+          )
       });
       this.buildDashboardResponseData(responce);
-        },
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleHALOPSADashbaord(databaseId).subscribe({
+        next: handleResponse,
         error: (error) => {
           this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
           console.log(error);
         }
-      }
-    )
+      })
+    }
   }
-  buildSampleSalesforceDashboard(container: ViewContainerRef , databaseId: any){
+  buildSampleSalesforceDashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleSalesforceDashbaord(databaseId).subscribe({next: (responce) => {
+
+    const handleResponse = (responce: any) => {
       const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
       queries.forEach((query: any) => {
         const obj ={
@@ -980,30 +1004,34 @@ export class TemplateDashboardService {
           joining_conditions:query.joining_conditions,
           dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
         } as any
-        this.workbechService.joiningTablesTest(obj).subscribe({next: (responce) => {
-          // this.buildDashboardResponseData(responce);
-            },
+          this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
             error: (error) => {
               this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
               console.log(error);
             }
-          }
-        )
+          })
       });
       this.buildDashboardResponseData(responce);
-      },
-      error: (error) => {
-        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-        console.log(error);
-      }
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleSalesforceDashbaord(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          console.log(error);
+        }
+      })
     }
-  )
   }
 
-  buildSampleOpenAIDashboard(container: ViewContainerRef , databaseId: any){
+  buildSampleOpenAIDashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
-    this.workbechService.buildSampleOpenAIDashboard(databaseId).subscribe({next: (responce) => {
+
+    const handleResponse = (responce: any) => {
       const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
       queries.forEach((query: any) => {
         const obj ={
@@ -1014,29 +1042,73 @@ export class TemplateDashboardService {
           joining_conditions:query.joining_conditions,
           dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
         } as any
-        this.workbechService.joiningTablesTest(obj).subscribe({next: (res) => {
-            // this.buildDashboardResponseData(res);
-            },
+          this.workbechService.joiningTablesTest(obj).subscribe({next: () => {
+              },
+              error: (error) => {
+                this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+                console.log(error);
+              }
+            }
+          )
+      });
+      this.buildDashboardResponseData(responce);
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleOpenAIDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          console.log(error);
+        }
+      })
+    }
+  }
+buildSampleTallyDashboard(container: ViewContainerRef, databaseId: any, responceData?: any) {
+  const componentRef = container.createComponent(InsightEchartComponent);
+  this.echartInstance = componentRef.instance;
+
+  const handleResponse = (responce: any) => {
+    const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+    queries.forEach((query: any) => {
+      const obj ={
+        query_set_id:query.queryset_id,
+        hierarchy_id:query.hierarchy_id,
+        joining_tables: query.joining_tables,
+        join_type:query.join_type,
+        joining_conditions:query.joining_conditions,
+        dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
+      } as any
+        this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
             error: (error) => {
               this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
               console.log(error);
             }
           }
         )
-      });
-      this.buildDashboardResponseData(responce);
-        },
-        error: (error) => {
-          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-          console.log(error);
-        }
+    });
+    this.buildDashboardResponseData(responce);
+    };
+
+  if(responceData){
+    handleResponse(responceData);
+  } else {
+    this.workbechService.buildSampleTallyDashboard(databaseId).subscribe({
+      next: handleResponse,
+      error: (error) => {
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+        console.log(error);
       }
-    )
+    })
   }
-buildSampleTallyDashboard(container: ViewContainerRef, databaseId: any) {
+  }
+buildSampleHubspotDashboard(container: ViewContainerRef, databaseId: any, responceData?: any) {
   const componentRef = container.createComponent(InsightEchartComponent);
   this.echartInstance = componentRef.instance;
-  this.workbechService.buildSampleTallyDashboard(databaseId).subscribe({next: (responce) => {
+
+  const handleResponse = (responce: any) => {
     const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
     queries.forEach((query: any) => {
       const obj ={
@@ -1047,58 +1119,29 @@ buildSampleTallyDashboard(container: ViewContainerRef, databaseId: any) {
         joining_conditions:query.joining_conditions,
         dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
       } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (res) => {
-          // this.buildDashboardResponseData(res);
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-            console.log(error);
+        this.workbechService.joiningTablesTest(obj).subscribe({next: () => {},
+            error: (error) => {
+              this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+              console.log(error);
+            }
           }
-        }
-      )
+        )
     });
     this.buildDashboardResponseData(responce);
-      },
+    };
+
+  if(responceData){
+    handleResponse(responceData);
+  } else {
+    this.workbechService.buildSampleHubspotDashboard(databaseId).subscribe({
+      next: handleResponse,
       error: (error) => {
         this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
         console.log(error);
       }
-    }
-  )
-}
-buildSampleHubspotDashboard(container: ViewContainerRef, databaseId: any) {
-  const componentRef = container.createComponent(InsightEchartComponent);
-  this.echartInstance = componentRef.instance;
-  this.workbechService.buildSampleHubspotDashboard(databaseId).subscribe({next: (responce) => {
-    const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
-    queries.forEach((query: any) => {
-      const obj ={
-        query_set_id:query.queryset_id,
-        hierarchy_id:query.hierarchy_id,
-        joining_tables: query.joining_tables,
-        join_type:query.join_type,
-        joining_conditions:query.joining_conditions,
-        dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
-      } as any
-      this.workbechService.joiningTablesTest(obj).subscribe({next: (res) => {
-          // this.buildDashboardResponseData(res);
-          },
-          error: (error) => {
-            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-            console.log(error);
-          }
-        }
-      )
-    });
-    this.buildDashboardResponseData(responce);
-      },
-      error: (error) => {
-        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
-        console.log(error);
-      }
-    }
-  )
-}
+    })
+  }
+  }
   private readonly KPI_MAX       = 8;
   private readonly KPI_PER_ROW   = 8;
   private readonly KPI_SIZE      = { cols: 5, rows: 4 };


### PR DESCRIPTION
## Summary
- refactor `buildSample*Dashboard` helpers to optionally accept response data
- update `smartDashboardFromConnection` to pass API response to helpers

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module '@angular/core')*
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_6878e8ff3f1c8320a89ce62c5aad1837