### PR TITLE
Fix protected dashboard API calls

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -61,6 +61,7 @@ import domtoimage from 'dom-to-image';
 import jsPDF from 'jspdf';
 import { i } from 'mathjs';
 import { SafeUrlPipe, SanitizeHtmlPipe } from '../../../shared/pipes/sanitize-html.pipe';
+import { AuthService } from '../../../shared/services/auth.service';
 
 interface TableRow {
   [key: string]: any;
@@ -201,6 +202,7 @@ export class SheetsdashboardComponent implements OnDestroy {
   isAuthenticated = false;
   protectedQuery = false;
   encryptedEmail: string | null = null;
+  userEmail: string | null = null;
   passkey: string = '';
   @ViewChild('passkeyModal') passkeyModal:any;
   publicHeader = false;
@@ -257,9 +259,19 @@ export class SheetsdashboardComponent implements OnDestroy {
 
   constructor(private workbechService:WorkbenchService,private route:ActivatedRoute,private router:Router,private screenshotService: ScreenshotService,
     private loaderService:LoaderService,private modalService:NgbModal, private viewTemplateService:ViewTemplateDrivenService,private toasterService:ToastrService,
-     private sanitizer: DomSanitizer,private cdr: ChangeDetectorRef, private http: HttpClient,private sharedService:SharedService,private cd:ChangeDetectorRef){
+     private sanitizer: DomSanitizer,private cdr: ChangeDetectorRef, private http: HttpClient,private sharedService:SharedService,private cd:ChangeDetectorRef,
+     private authService: AuthService){
     this.dashboard = [];
     this.isAuthenticated = !!localStorage.getItem('currentUser');
+    if(localStorage.getItem('protected_email')){
+      this.userEmail = localStorage.getItem('protected_email');
+    }
+    if(this.isAuthenticated){
+      const u = this.authService.getCurrentUser();
+      if(u?.email){
+        this.userEmail = u.email;
+      }
+    }
     const currentUrl = this.router.url;
     this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
       echarts.registerMap('world', geoJson); 
@@ -589,6 +601,15 @@ export class SheetsdashboardComponent implements OnDestroy {
   ngOnInit() {
     this.isAuthenticated = !!localStorage.getItem('currentUser');
     this.hasProtectedAccess = localStorage.getItem('protected_access') === 'true';
+    if(this.hasProtectedAccess){
+      this.userEmail = localStorage.getItem('protected_email') || this.userEmail;
+    }
+    if(this.isAuthenticated){
+      const u = this.authService.getCurrentUser();
+      if(u?.email){
+        this.userEmail = u.email;
+      }
+    }
     if(this.hasProtectedAccess || this.isAuthenticated){
       this.isProtectedValidated = true;
     }
@@ -5542,9 +5563,10 @@ kpiData?: KpiData;
 
   //public apis
   getSavedDashboardDataPublic(){
-    const obj ={
-      dashboard_id:this.dashboardId
-    }
+    const obj : any = {
+      dashboard_id:this.dashboardId,
+      email: this.userEmail
+    };
     this.workbechService.getSavedDashboardDataPublic(obj).subscribe({
       next:(data)=>{
         console.log('savedDashboard',data);
@@ -5752,8 +5774,9 @@ kpiData?: KpiData;
       email: this.encryptedEmail
     };
     this.workbechService.validateProtectedKey(obj).subscribe({
-      next: ()=>{
+      next: (res:any)=>{
         this.isProtectedValidated = true;
+        this.userEmail = res?.email || this.userEmail;
         modal.close();
         this.loadProtectedDashboard();
       },

--- a/src/app/shared/services/auth.service.ts
+++ b/src/app/shared/services/auth.service.ts
@@ -206,13 +206,24 @@ getTokensalesforce(data:any){
          localStorage.clear();
          //this.userSubject.next(null);
          window.location.reload();
-  
-         this.router.navigate(['/authentication/signin']) 
+
+         this.router.navigate(['/authentication/signin'])
         //  .then(() => {
-        //  }); 
+        //  });
          return of({ success: false });
   }
-  
+
+  getCurrentUser(){
+    try {
+      const data = localStorage.getItem('username');
+      if(data){
+        const parsed = JSON.parse(data);
+        return { email: parsed.userName };
+      }
+    } catch (err) {}
+    return null;
+  }
+
   updatePassword(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];


### PR DESCRIPTION
## Summary
- send the viewer's email when loading protected dashboards
- store the email from localStorage or AuthService
- capture email returned by passkey validation

## Testing
- `npm test` *(fails: ng not found)*
- `npx tsc --noEmit` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_b_6878ec9180c883209b360b85bcac619b