### PR TITLE
Add self-hosted embed loader to Analytify SDK

### DIFF
--- a/analytify-sdk/README.md
+++ b/analytify-sdk/README.md
@@ -74,3 +74,18 @@
    // ...
  </script>
  ```
+### Full Platform Embedding
+
+To embed the entire Analytify interface into your application use `loadSdkProject`:
+
+```html
+<div id="analytify-container"></div>
+<script src="analytify-sdk.js"></script>
+<script>
+  AnalytifySDK.loadSdkProject({
+    clientId: 'your-client-id',
+    clientSecret: 'your-client-secret',
+    container: document.getElementById('analytify-container')
+  });
+</script>
+```

--- a/analytify-sdk/src/index.js
+++ b/analytify-sdk/src/index.js
@@ -155,8 +155,62 @@ export function embedSheet(options) {
     });
 }
 
+/**
+ * Load the full Analytify platform inside a container.
+ * Handles authentication and injects an iframe pointing to /embed/sdk.
+ * @param {{clientId:string, clientSecret:string, container:string|HTMLElement, options?:{landingRoute?:string}}} opts
+ * @returns {Promise<HTMLIFrameElement>|void}
+ */
+export function loadSdkProject(opts) {
+  if (!opts || !opts.clientId || !opts.clientSecret || !opts.container) {
+    console.error('AnalytifySDK.loadSdkProject: Missing required options');
+    return;
+  }
+  const containerEl = typeof opts.container === 'string'
+    ? document.querySelector(opts.container)
+    : opts.container;
+  if (!containerEl) {
+    console.error('AnalytifySDK.loadSdkProject: Container not found', opts.container);
+    return;
+  }
+  const base = _config.apiBaseUrl;
+  const endpoint = _config.tokenEndpoint + '/sdk-authenticate';
+  return fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ clientId: opts.clientId, clientSecret: opts.clientSecret })
+  })
+    .then(res => {
+      if (!res.ok) {
+        throw new Error('SDK authentication failed: ' + res.status + ' ' + res.statusText);
+      }
+      return res.json();
+    })
+    .then(data => {
+      const token = data.data?.access_token || data.accessToken || data.token;
+      if (!token) throw new Error('Missing token in response');
+      localStorage.setItem('currentUser', JSON.stringify({ Token: token }));
+      let src = base + '/embed/sdk?token=' + encodeURIComponent(token) + '&clientId=' + encodeURIComponent(opts.clientId);
+      if (opts.options && opts.options.landingRoute) {
+        src += '&route=' + encodeURIComponent(opts.options.landingRoute);
+      }
+      const iframe = document.createElement('iframe');
+      iframe.src = src;
+      iframe.style.border = 'none';
+      iframe.style.width = '100%';
+      iframe.style.height = '100%';
+      containerEl.innerHTML = '';
+      containerEl.appendChild(iframe);
+      return iframe;
+    })
+    .catch(err => {
+      console.error('AnalytifySDK.loadSdkProject error:', err);
+    });
+}
+
 export default {
   init,
   loadDashboard,
-  embedSheet
+  embedSheet,
+  loadSdkProject
 };

--- a/public/analytify-sdk.js
+++ b/public/analytify-sdk.js
@@ -122,7 +122,7 @@
    * @param {{sheetId: string|number, container: string|HTMLElement, filters?: object, width?: string, height?: string}} options
    * @returns {Promise<HTMLIFrameElement>|void}
    */
-    function embedSheet(options) {
+  function embedSheet(options) {
       console.log("loadSheet");
       if (!_config.clientId || !_config.apiBaseUrl) {
         console.error('AnalytifySDK.embedSheet: SDK not initialized; call init() first');
@@ -158,14 +158,63 @@
           // return iframe;
         })
         .catch(function (err) {
-          console.error('AnalytifySDK.sheetload error:', err);
-        });
+        console.error('AnalytifySDK.sheetload error:', err);
+      });
+  }
+
+  function loadSdkProject(opts) {
+    if (!opts || !opts.clientId || !opts.clientSecret || !opts.container) {
+      console.error('AnalytifySDK.loadSdkProject: Missing required options');
+      return;
     }
+    var containerEl = typeof opts.container === 'string'
+      ? document.querySelector(opts.container)
+      : opts.container;
+    if (!containerEl) {
+      console.error('AnalytifySDK.loadSdkProject: Container not found', opts.container);
+      return;
+    }
+    var base = _config.apiBaseUrl || EMBED_BASE.replace(/embed\/?$/, '');
+    var endpoint = _config.tokenEndpoint + '/sdk-authenticate';
+    return fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ clientId: opts.clientId, clientSecret: opts.clientSecret })
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          throw new Error('SDK authentication failed: ' + res.status + ' ' + res.statusText);
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        var token = (data.data && data.data.access_token) || data.accessToken || data.token;
+        if (!token)
+          throw new Error('Missing token in response');
+        localStorage.setItem('currentUser', JSON.stringify({ Token: token }));
+        var src = base + '/embed/sdk?token=' + encodeURIComponent(token) + '&clientId=' + encodeURIComponent(opts.clientId);
+        if (opts.options && opts.options.landingRoute) {
+          src += '&route=' + encodeURIComponent(opts.options.landingRoute);
+        }
+        var iframe = document.createElement('iframe');
+        iframe.src = src;
+        iframe.style.border = 'none';
+        iframe.style.width = '100%';
+        iframe.style.height = '100%';
+        containerEl.innerHTML = '';
+        containerEl.appendChild(iframe);
+        return iframe;
+      })
+      .catch(function (err) {
+        console.error('AnalytifySDK.loadSdkProject error:', err);
+      });
+  }
 
   // Expose the two entry points
   global.AnalytifySDK = {
     init: init,
     loadDashboard: loadDashboard,
-    embedSheet: embedSheet
+    embedSheet: embedSheet,
+    loadSdkProject: loadSdkProject
   };
 })(typeof window !== 'undefined' ? window : this);

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -45,6 +45,10 @@ export const App_Route: Route[] = [
         loadComponent: () =>
           import('../app/components/workbench/sheet-sdk/sheet-sdk.component').then((m) => m.SheetSdkComponent)
       },
+      {
+        path: 'embed/sdk',
+        loadChildren: () => import('../app/embed/embed.module').then(m => m.EmbedModule)
+      },
       // { path: '', component: ContentLayoutComponent, children: content },
       { path: '', component: AuthenticationLayoutComponent, children: authen },
       // { path: '', component: LandingpageLayoutComponent, children: landing },

--- a/src/app/embed/embed.module.ts
+++ b/src/app/embed/embed.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { WorkbenchLayoutsComponent } from '../shared/layout-components/layouts/workbench-layouts/workbench-layouts.component';
+import { workbench } from '../shared/routes/workbenckroutes';
+import { sdkAuthGuard } from './sdk-auth.guard';
+
+const routes: Routes = [
+  {
+    path: '',
+    component: WorkbenchLayoutsComponent,
+    canActivate: [sdkAuthGuard],
+    children: workbench
+  }
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class EmbedModule {}
+

--- a/src/app/embed/sdk-auth.guard.ts
+++ b/src/app/embed/sdk-auth.guard.ts
@@ -1,0 +1,17 @@
+import { CanActivateFn, Router } from '@angular/router';
+import { inject } from '@angular/core';
+
+export const sdkAuthGuard: CanActivateFn = (route) => {
+  const router = inject(Router);
+  let current = localStorage.getItem('currentUser');
+  if (!current) {
+    const token = route.queryParamMap.get('token');
+    if (token) {
+      localStorage.setItem('currentUser', JSON.stringify({ Token: token }));
+      return true;
+    }
+    router.navigate(['authentication/login']);
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## Summary
- support full portal embedding via `loadSdkProject`
- document new embed method in SDK README
- expose new embed route in Angular app
- add `EmbedModule` and `sdkAuthGuard` for iframe usage

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_687e7124057483208cc39ccdaf35ef75