### PR TITLE
Support tree chart option

### DIFF
--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -1175,6 +1175,11 @@ try {
       }
       chartType : string ='';
       chartsOptionsSet(){
+        if(this.chartId === 16){
+          // data already extracted; just set chart type for tree chart and exit
+          this.chartType = 'tree';
+          return;
+        }
         if(this.kpi){
           this.KPIChart();
           return;
@@ -1182,6 +1187,9 @@ try {
           this.chartType = 'horizontalBar'
         }else if(this.pivotTable){
           this.chartType = 'pivotTable';
+          return;
+        } else if(this.treeChart){
+          this.chartType = 'tree';
           return;
         }
         const cfg = this.chartRenderService.getChartConfig(this.chartId);
@@ -1618,6 +1626,7 @@ try {
   funnel = false;
   guage = false;
   calendar = false;
+  treeChart = false;
   chartDisplay(table:boolean,bar:boolean,area:boolean,line:boolean,pie:boolean,sidebysideBar:boolean,stocked:boolean,barLine:boolean,
     horizentalStocked:boolean,grouped:boolean,multiLine:boolean,donut:boolean,radar:boolean,kpi:any,heatMap:any,funnel:any,guage:boolean,map:boolean,calendar:boolean,pivotTable:boolean,horizontalBar:boolean,chartId:any){
     this.table = table;


### PR DESCRIPTION
## Summary
- add `treeChart` state flag
- update `chartsOptionsSet()` to handle tree charts and ignore other config when `chartId` is 16

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_688a64f82bb083209f1777d86d68f190