### PR TITLE
Add TreeChart support

### DIFF
--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -85,6 +85,7 @@ export class InsightEchartComponent {
   @Input() leftLegend:any;
   @Input() isDistributed : any;
   @Input() mapChartOptions:any;
+  @Input() treeData: any;
   @Input() actionId:any;
   @Input() SDKChartOptions: any;
   @Input() isRadarDistribution:any;
@@ -102,6 +103,7 @@ export class InsightEchartComponent {
 
   series: any[] = [];
   chartOptions: any = {};
+  private treeChartData: any[] = [];
   constructor(private cdr: ChangeDetectorRef,private http: HttpClient){}
 
  
@@ -1651,6 +1653,48 @@ heatMapChart(){
   ],
 };
 }
+
+treeChart(treeData?: any[]) {
+  if (treeData) {
+    this.treeChartData = treeData;
+  } else if (this.treeData) {
+    this.treeChartData = this.treeData;
+  } else if (this.chartsColumnData) {
+    this.treeChartData = this.chartsColumnData.map((name: any) => ({ name, children: [] }));
+  }
+  this.chartOptions = {
+    tooltip: {
+      trigger: 'item',
+      triggerOn: 'mousemove'
+    },
+    series: [
+      {
+        type: 'tree',
+        data: this.treeChartData,
+        top: '5%',
+        left: '7%',
+        bottom: '2%',
+        right: '20%',
+        symbolSize: 7,
+        label: {
+          position: 'left',
+          verticalAlign: 'middle',
+          align: 'right'
+        },
+        leaves: {
+          label: {
+            position: 'right',
+            verticalAlign: 'middle'
+          }
+        },
+        expandAndCollapse: true,
+        animationDuration: 550,
+        animationDurationUpdate: 750
+      }
+    ]
+  };
+  return this.chartOptions;
+}
 calendarChart() {
   let calendarData: any[] = [];
   let years: Set<any> = new Set();
@@ -2054,6 +2098,9 @@ chartInitialize(){
   else if(this.chartType === 'heatmap'){
     this.heatMapChart();
   }
+  else if(this.chartType === 'tree'){
+    this.treeChart();
+  }
   else if(this.chartType === 'calendar'){
     this.calendarChart();
   }
@@ -2109,6 +2156,10 @@ chartInitialize(){
     if(changes['mapChartOptions'] ){
       this.chartOptions = this.mapChartOptions;
       this.chartInstance?.setOption(this.chartOptions, true);
+    }
+    if(changes['treeData']){
+      this.treeChartData = this.treeData;
+      this.resetchartoptions();
     }
     if(changes['isZoom']){
       if (this.chartInstance) {
@@ -3962,6 +4013,12 @@ updateSeries(){
 //   }
 // }
   onChartClick(event: any) {
+    if(this.chartType === 'tree'){
+      // avoid duplicate drilldown calls if children already loaded
+      if(event.data && Array.isArray(event.data.children) && event.data.children.length > 0){
+        return;
+      }
+    }
     if (this.drillDownIndex < this.draggedDrillDownColumns.length - 1) {
       console.log('X-axis value:', event.name);
       let nestedKey = this.draggedDrillDownColumns[this.drillDownIndex];

--- a/src/app/components/workbench/sheet-sdk/sheet-sdk.component.ts
+++ b/src/app/components/workbench/sheet-sdk/sheet-sdk.component.ts
@@ -148,6 +148,9 @@ export class SheetSdkComponent {
           case 10:
             this.chartType = 'donut';
             break;
+          case 16:
+            this.chartType = 'tree';
+            break;
           case 27:
             this.chartType = 'funnel';
             break;

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2594,7 +2594,7 @@
                                 @if(isApexCharts && !table && !kpi && !pivotTable){
               <!-- @if(bar && chartId){ -->
 
-                <app-insight-apex [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisColumnData]="dualAxisColumnData"
+                <app-insight-apex [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [dualAxisColumnData]="dualAxisColumnData"
                 [dualAxisRowData]="dualAxisRowData" [tablePreviewRow]="tablePreviewRow" [chartType]="chartType" [xGridSwitch]="xGridSwitch"
                 [xLabelSwitch]="xLabelSwitch" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [xLabelFontFamily]="xLabelFontFamily"
                 [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [backgroundColor]="backgroundColor" [color]="color"
@@ -2618,7 +2618,7 @@
                     <div echarts [options]="eBarChartOptions" class="echart-charts"></div>
                 </div> -->
 
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor"
                 [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor"
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
@@ -2630,7 +2630,7 @@
             </div>          
             } @else if(horizontalBar && chartId ){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor"
                 [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor"
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
@@ -2644,7 +2644,7 @@
 
             @else if(funnel && chartId){         
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [color]="color" [backgroundColor]="backgroundColor" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed"
                     [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)" [isMeasureDistribution]="isMeasureDistribution"
                     [measureColorRanges]="measureColorRanges"></app-insight-echart>
@@ -2658,15 +2658,15 @@
                     [xlabelAlignment]="xlabelAlignment" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                     [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" 
                     [dataLabelsColor]="dataLabelsColor"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [selectedColorScheme]="selectedColorScheme"
-                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
+                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                 </div>
                 }
             @else if(sidebyside && chartId){         
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [backgroundColor]="backgroundColor" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                         [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment" [selectedColorScheme]="selectedColorScheme"
-                        [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [color]="color" [yGridColor]="yGridColor" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                        [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch" [color]="color" [yGridColor]="yGridColor" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                         [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize"
                         [dataLabelsColor]="dataLabelsColor"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                         [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
@@ -2680,7 +2680,7 @@
                         [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [selectedColorScheme]="selectedColorScheme"
                         [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" 
                         [dataLabelsColor]="dataLabelsColor"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                        [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
+                        [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                     </div>
             }
             @else if(horizentalStocked && chartId){         
@@ -2690,13 +2690,13 @@
                     [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [xlabelAlignment]="xlabelAlignment" [selectedColorScheme]="selectedColorScheme"
                     [yLabelColor]="yLabelColor" [yGridColor]="yGridColor" [yLabelSwitch]="yLabelSwitch" [yGridSwitch]="yGridSwitch"  [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
+                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                 </div>
         }
                 
             @else if(area && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" 
                 [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize"
                 [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor"
@@ -2707,7 +2707,7 @@
             }
             @else if(line && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                 [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment" [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" 
                 [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily" [xLabelFontSize]="xLabelFontSize"
                 [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor"
@@ -2719,7 +2719,7 @@
             }
             @else if(pie && chartId){
             <div class="card-body">
-                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                 [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                 [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                 [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
@@ -2729,7 +2729,7 @@
             }
             @else if(donut && chartId){
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [donutSize]="donutSize" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [donutSize]="donutSize" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels" [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"
                     [donutDecimalPlaces]="donutDecimalPlaces" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
@@ -2744,7 +2744,7 @@
                     [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [barColor]="barColor" [lineColor]="lineColor"  [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                     [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor"
                     [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [dataLabelsLineFontPosition]="dataLabelsLineFontPosition"
-                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
+                    [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                 </div>
                 }
                 @else if(multiLine && chartId){
@@ -2755,20 +2755,20 @@
                         [yLabelColor]="yLabelColor" [yLabelSwitch]="yLabelSwitch" [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [selectedColorScheme]="selectedColorScheme"
                         [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" 
                         [dataLabelsColor]="dataLabelsColor"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                        [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
+                        [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                     </div>
                     }
             @else if(radar && chartId){
                 <div class="card-body">
                     <app-insight-echart [chartType]="chartType" [color]="color"  [isBold]="isBold" [radarRowData]="radarRowData" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [xLabelColor]="xLabelColor" [dataLabels]="dataLabels" [dataLabelsFontFamily]="dataLabelsFontFamily"  [isRadarDistribution]="isRadarDistribution" [selectedColorScheme]="selectedColorScheme"
-                    [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                    [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                     [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                 </div>
                 }
                 @else if(map && chartId){
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
+                        <app-insight-echart [isZoom]="isZoom" [isBold]="isBold"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [chartsRowData]="chartsRowData" [dualAxisRowData]="dualAxisRowData" [dualAxisColumnData]="dualAxisColumnData"
                         [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [backgroundColor]="backgroundColor" [xlabelAlignment]="xlabelAlignment"
                         [xGridColor]="xGridColor" [xGridSwitch]="xGridSwitch" [xLabelColor]="xLabelColor" [xLabelSwitch]="xLabelSwitch" [xLabelFontFamily]="xLabelFontFamily"
                         [xLabelFontSize]="xLabelFontSize" [xlabelFontWeight]="xlabelFontWeight" [yLabelColor]="yLabelColor" [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch"
@@ -2782,7 +2782,7 @@
                     
                 @else if(calendar){
                     <div class="card-body">
-                        <app-insight-echart [isZoom]="isZoom"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [chartsRowData]="chartsRowData" [selectedColorScheme]="selectedColorScheme"
+                        <app-insight-echart [isZoom]="isZoom"  [chartType]="chartType" [chartsColumnData]="chartsColumnData" [treeData]="treeData" [chartsRowData]="chartsRowData" [selectedColorScheme]="selectedColorScheme"
                         [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                     </div>
                 }
@@ -2793,7 +2793,7 @@
                         [backgroundColor]="backgroundColor" [xLabelSwitch]="xLabelSwitch" [xLabelColor]="xLabelColor" [xLabelFontSize]="xLabelFontSize" [xLabelFontFamily]="xLabelFontFamily" [selectedColorScheme]="selectedColorScheme"
                         [xlabelFontWeight]="xlabelFontWeight" [yLabelSwitch]="yLabelSwitch" [yLabelColor]="yLabelColor" [yLabelFontSize]="[yLabelFontSize]" [yLabelFontFamily]="yLabelFontFamily" [ylabelFontWeight]="ylabelFontWeight"
                         [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor"
-                        [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                        [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData" [treeData]="treeData"
                         [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" (saveOrUpdateChart)="setChartOptions($event)"></app-insight-echart>
                     </div>
                 }
@@ -3582,7 +3582,10 @@
                                                             <a href="javascript:void(0);"  triggers="hover" ngbTooltip="Heat Map" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,false,false,false,26)"><img src="./assets/images/charts/heatmap-new.png" class="rounded-2 w-90 mrk-t border p-1 chart-icon" [ngClass]="{'active': heatMap}"></a>
                                                         </div>
                                                         <div *ngIf="isEChatrts" class="col-3 px-2 mt-2" [ngClass]="{'disabled': ( draggedRows?.length<1 || draggedColumns?.length!=1)}">
-                                                            <a href="javascript:void(0);"  triggers="hover" ngbTooltip="World Map" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,29)"><img src="./assets/images/charts/world-map.png" class="rounded-2 w-90 mrk-t border p-1 chart-icon" [ngClass]="{'active': map}"></a>
+                                                        <a href="javascript:void(0);"  triggers="hover" ngbTooltip="World Map" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,29)"><img src="./assets/images/charts/world-map.png" class="rounded-2 w-90 mrk-t border p-1 chart-icon" [ngClass]="{'active': map}"></a>
+                                                        </div>
+                                                        <div class="col-3 px-2 mt-2" [ngClass]="{'disabled': ( draggedColumns?.length<1 )}">
+                                                            <a href="javascript:void(0);"  triggers="hover" ngbTooltip="Tree Chart" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,16)"><img src="./assets/images/charts/tree-chart.png" class="rounded-2 w-90 mrk-t border p-1 chart-icon" [ngClass]="{'active': treeChart}"></a>
                                                         </div>
                                                     </div>
                                                 </div>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -268,6 +268,7 @@ export class SheetsComponent{
   draggedMeasureValues = [] as any;
   drillDownIndex : number = 0;
   originalData : any ;
+  treeData: any[] = [];
   dateDrillDownSwitch : boolean = false;
   drillDownObject: any[] = [];
   sheetCustomQuery: any;
@@ -293,6 +294,7 @@ export class SheetsComponent{
   maxValueGuage: number = 100; // Default maximum value
   gaugeDisplayMode= 'both'; // Default gauge display mode
   map: boolean = false;
+  treeChart: boolean = false;
 
   guageNumber:any;
   eFunnelChartOptions: any;
@@ -683,12 +685,36 @@ try {
      this.router.navigate(['/analytify/database-connection/sheets'+'/'+idToPass+'/'+encodedqurysetId+'/'+encodedDsQuerySetId])
   
     }
-  }
+      }
 
-  }
-  goToConnections(){
-    this.router.navigate(['/analytify/datasources/view-connections'])
-  }
+      }
+      addChildrenToTree(tree: any[], path: string[], children: string[]) {
+        if(!tree || path.length === 0){
+          return;
+        }
+        const name = path[0];
+        const node = tree.find((n:any)=>n.name === name);
+        if(!node){
+          return;
+        }
+        if(path.length === 1){
+          node.children = node.children || [];
+      children.forEach(ch => {
+        if(!node.children.some((c:any)=>c.name === ch)){
+          node.children.push({name: ch, children: [], collapsed: true});
+        }
+      });
+      } else {
+        this.addChildrenToTree(node.children || (node.children=[]), path.slice(1), children);
+      }
+      }
+
+      resetTreeChartState(){
+        this.treeData = [];
+      }
+      goToConnections(){
+        this.router.navigate(['/analytify/datasources/view-connections'])
+      }
   toggleSubMenu(menu: any) {
     menu.expanded = !menu.expanded;
   }
@@ -846,6 +872,7 @@ try {
               this.guage = false;
               this.funnel = false;
               this.calendar = false;
+    this.treeChart = false;
               this.map=false;
               // this.tableDisplayPagination();
             } else if(((this.pie || this.bar || this.horizontalBar || this.area || this.line || this.donut || this.funnel || this.calendar) && (this.draggedColumns.length > 1 || this.draggedRows.length > 1))) {
@@ -870,6 +897,7 @@ try {
               this.funnel = false;
               this.guage = false;
               this.calendar = false;
+    this.treeChart = false;
               this.map = false;
               // this.sidebysideBar();
               this.resetCustomizations();
@@ -1170,6 +1198,14 @@ try {
           //   const aa = { col: this.chartsColumnData[i], row: this.chartsRowData[i] };
           //   this.chartsData.push(aa);
           // }
+          if(this.chartId === 16){
+            const path = this.drillDownObject.map((o:any) => Object.values(o)[0]);
+            if(path.length === 0){
+              this.treeData = this.chartsColumnData.map((n:any)=>({name:n, children:[], collapsed: true}));
+            } else {
+              this.addChildrenToTree(this.treeData, path, this.chartsColumnData);
+            }
+          }
         }
 
       }
@@ -1279,6 +1315,9 @@ try {
       if (this.dateList.includes(element.data_type)) {
         this.dateFormat(element, event.currentIndex, 'year');
       } else {
+        if(this.chartId === 16){
+          this.resetTreeChartState();
+        }
         this.dataExtraction(false);
       }
       this.checkDateFormatForYOY();
@@ -1555,6 +1594,9 @@ try {
       }
       
     }
+   if(this.chartId === 16){
+     this.resetTreeChartState();
+   }
    this.dataExtraction(false);
    this.checkDateFormatForYOY();
   }
@@ -1635,6 +1677,7 @@ try {
     this.multiLine = multiLine;
     this.donut = donut;
     this.chartId = chartId;
+    this.treeChart = chartId === 16;
     this.radar = radar;
     this.kpi = kpi;
     this.heatMap = heatMap;
@@ -2136,6 +2179,7 @@ try {
       this.heatMap = false;
       this.funnel = false;
       this.calendar = false;
+    this.treeChart = false;
       this.guage = false;
       this.banding = false;
       this.kpiFontSize = '3';
@@ -2724,6 +2768,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.funnel = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
     this.itemsPerPage = this.sheetResponce?.results?.items_per_page;
     if (isDashboardTransfer) {
       let rowCountData: any;
@@ -2774,6 +2819,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.funnel = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
     this.pivotTableDatatransform(false);
   }
   if(responce.chart_id == 25){
@@ -2820,6 +2866,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
   }
   if(responce.chart_id == 29){
     this.http.get('./assets/maps/world.json').subscribe((geoJson: any) => {
@@ -2846,6 +2893,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = true;
     this.calendar = false;
+    this.treeChart = false;
     this.chartType = 'map';
   }
  if(responce.chart_id == 6){
@@ -2874,6 +2922,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
   if(responce.chart_id == 14){
   // this.chartsRowData = this.sheetResponce.results.barYaxis;
@@ -2901,6 +2950,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 24){
   this.chartType = 'pie';
@@ -2926,6 +2976,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 13){
   this.chartType = 'line';
@@ -2951,6 +3002,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 17){
   this.chartType = 'area';
@@ -2976,6 +3028,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 7){
   this.chartType = 'sidebyside';
@@ -3001,6 +3054,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 5){
   this.chartType = 'stocked';
@@ -3026,6 +3080,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 4){
   this.chartType = 'barline';
@@ -3051,6 +3106,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 12){
   this.chartType = 'radar';
@@ -3076,6 +3132,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 2){
   this.chartType = 'hstocked';
@@ -3101,6 +3158,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.guage = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 3){
   this.chartType = 'hgrouped';
@@ -3126,6 +3184,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 8){
   this.chartType = 'multiline';
@@ -3151,6 +3210,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 10){
   this.chartType = 'donut';
@@ -3176,6 +3236,33 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
+ }
+ if(responce.chart_id == 16){
+  this.chartType = 'tree';
+  this.bar = false;
+  this.horizontalBar = false;
+  this.table = false;
+  this.pivotTable = false;
+    this.pie = false;
+    this.line = false;
+    this.area = false;
+    this.sidebyside = false;
+    this.stocked = false;
+    this.barLine = false;
+    this.horizentalStocked = false;
+    this.grouped = false;
+    this.multiLine = false;
+    this.donut = false;
+    this.radar = false;
+    this.kpi = false;
+    this.heatMap = false;
+    this.funnel = false;
+    this.guage = false;
+    this.map = false;
+    this.calendar = false;
+    this.treeChart = false;
+    this.treeChart = true;
  }
  if(responce.chart_id == 26){
   this.chartType = 'heatmap';
@@ -3200,6 +3287,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 27){
   this.chartType = 'funnel';
@@ -3224,6 +3312,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 28){
   this.customMinMaxGuage();
@@ -3249,6 +3338,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = true;
     this.map = false;
     this.calendar = false;
+    this.treeChart = false;
  }
  if(responce.chart_id == 11){
   this.chartType = 'calendar';
@@ -3605,6 +3695,9 @@ trackByFn(index: number, item: any): number {
         this.filter_id=responce.filter_id
         this.dimetionMeasure.push({"col_name":this.filterName,"data_type":this.filterType,"filter_id":responce.filter_id,"top_bottom":this.activeTabId === 4 ? ['top'] : null});
         this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom && column.top_bottom.length>0);
+        if(this.chartId === 16){
+          this.resetTreeChartState();
+        }
         this.dataExtraction(false);
         this.filterDataArray.clear();
         this.filterDateRange = [];
@@ -3815,6 +3908,9 @@ trackByFn(index: number, item: any): number {
     this.workbechService.filterPut(obj).subscribe({next: (responce:any) => {
           console.log(responce);
           this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom && column.top_bottom.length>0);
+          if(this.chartId === 16){
+            this.resetTreeChartState();
+          }
           this.dataExtraction(false);
           this.filterDataArray.clear();
           this.filterDateRange = [];
@@ -3839,8 +3935,11 @@ trackByFn(index: number, item: any): number {
         this.dimetionMeasure.splice(index, 1);
        let index1 = this.filterId.findIndex((i:any) => i == filterId);
          this.filterId.splice(index1, 1);
-         this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom && column.top_bottom.length>0);
-         this.dataExtraction(false);
+        this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom && column.top_bottom.length>0);
+        if(this.chartId === 16){
+          this.resetTreeChartState();
+        }
+        this.dataExtraction(false);
       },
       error: (error) => {
         console.log(error);
@@ -4781,6 +4880,10 @@ customizechangeChartPlugin() {
           let columnData = [item.column,item.data_type,'',''];
           this.heirarchyColumnData.push(columnData);
         }
+        if(this.chartId === 16){
+          this.resetTreeChartState();
+          this.dataExtraction(false);
+        }
   }
   removeDrillDownColumn(index:any,column:any){
        
@@ -4797,6 +4900,9 @@ customizechangeChartPlugin() {
       this.drillDownObject = this.drillDownObject.slice(0, index - 1);
       this.drillDownIndex = index - 1;
     } 
+       if(this.chartId === 16){
+         this.resetTreeChartState();
+       }
        this.dataExtraction(false);
       }
       draggedMeasureValuesData = [] as any;
@@ -6604,6 +6710,7 @@ customizechangeChartPlugin() {
       this.guage = false;
       this.funnel = false;
       this.calendar = false;
+    this.treeChart = false;
       this.map = false;
     }
     sortColumn : any = 'select';

--- a/src/app/services/chart-render.service.ts
+++ b/src/app/services/chart-render.service.ts
@@ -21,6 +21,7 @@ export interface ChartFlags {
   map: boolean;
   calendar: boolean;
   pivotTable: boolean;
+  treeChart: boolean;
 }
 
 export interface ChartConfig {
@@ -51,6 +52,7 @@ export class ChartRenderService {
     map: false,
     calendar: false,
     pivotTable: false,
+    treeChart: false,
   };
 
   private chartConfigMap: Record<number, ChartConfig> = {
@@ -65,6 +67,7 @@ export class ChartRenderService {
     3: { chartType: 'hgrouped', flags: { ...this.baseFlags, grouped: true } },
     8: { chartType: 'multiline', flags: { ...this.baseFlags, multiLine: true } },
     10: { chartType: 'donut', flags: { ...this.baseFlags, donut: true } },
+    16: { chartType: 'tree', flags: { ...this.baseFlags, treeChart: true } },
     12: { chartType: 'radar', flags: { ...this.baseFlags, radar: true } },
     26: { chartType: 'heatmap', flags: { ...this.baseFlags, heatMap: true } },
     27: { chartType: 'funnel', flags: { ...this.baseFlags, funnel: true } },


### PR DESCRIPTION
## Summary
- implement TreeChart chart type with id 16
- register TreeChart in chart rendering service
- handle TreeChart selection in Sheet SDK and Sheets components
- render TreeChart via ECharts tree series
- manage recursive drilldowns in Sheets logic
- display TreeChart option in the sheet UI
- avoid redundant drilldown API calls
- reset TreeChart on column or filter changes
- remove tree-chart.png asset

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6889136987c883208e9eebf3aa79df54