### PR TITLE
Add Embed Project integration option

### DIFF
--- a/src/app/components/workbench/configure/configure.component.html
+++ b/src/app/components/workbench/configure/configure.component.html
@@ -102,11 +102,22 @@
                 </li>
 
                 <li [ngbNavItem]="'embedsdk'" class="mt-2 general-tab">
-                    <a ngbNavLink><i class="fe fe-code me-1"></i> Embed SDK</a>
+                    <a ngbNavLink (click)="selectedEmbedType = 'embed-sdk'"><i class="fe fe-code me-1"></i> Embed SDK</a>
                     <ng-template ngbNavContent id="embedsdk">
                          <div class="card profile-card">
                             <div class="card-body">
-                                <app-embed-sdk></app-embed-sdk>
+                                <app-embed-sdk [embedType]="selectedEmbedType"></app-embed-sdk>
+                            </div>
+                         </div>
+                    </ng-template>
+                </li>
+
+                <li [ngbNavItem]="'embedproject'" class="mt-2 general-tab">
+                    <a ngbNavLink (click)="selectedEmbedType = 'embed-project'"><i class="fe fe-code me-1"></i> Embed Project</a>
+                    <ng-template ngbNavContent id="embedproject">
+                         <div class="card profile-card">
+                            <div class="card-body">
+                                <app-embed-sdk [embedType]="selectedEmbedType"></app-embed-sdk>
                             </div>
                          </div>
                     </ng-template>

--- a/src/app/components/workbench/configure/configure.component.ts
+++ b/src/app/components/workbench/configure/configure.component.ts
@@ -25,6 +25,7 @@ export class ConfigureComponent implements OnInit {
   errorMessage: string = '';
   showPassword: boolean = false;
   activeTab = 'configure';
+  selectedEmbedType = 'embed-sdk';
   dashboardId:any;
   sheetId:any;
   dbId:any;

--- a/src/app/components/workbench/embed-sdk/embed-sdk.component.html
+++ b/src/app/components/workbench/embed-sdk/embed-sdk.component.html
@@ -6,7 +6,7 @@
     <div class="col-lg-6 mb-4">
       <div class="card shadow-sm h-100">
         <div class="card-header bg-primary text-white">
-          <h5 class="mb-0">Configure SDK</h5>
+          <h5 class="mb-0">{{ isProjectSDK ? 'Embed Project' : 'Configure SDK' }}</h5>
         </div>
         <div class="card-body">
           <form #sdkForm="ngForm" (ngSubmit)="submitSDKKeys()">

--- a/src/app/components/workbench/embed-sdk/embed-sdk.component.ts
+++ b/src/app/components/workbench/embed-sdk/embed-sdk.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { SharedModule } from '../../../shared/sharedmodule';
@@ -13,6 +13,7 @@ import { WorkbenchService } from '../workbench.service';
   styleUrl: './embed-sdk.component.scss'
 })
 export class EmbedSdkComponent {
+  @Input() embedType: string = 'embed-sdk';
   userName!: string;
   apibaseurl!: string;
   disableSDKName : boolean = false;
@@ -27,6 +28,7 @@ export class EmbedSdkComponent {
   showNotifier: boolean = false;
   isSheetSDK: boolean = false;
   isDashboardSDK: boolean = false;
+  isProjectSDK: boolean = false;
   sheetId!: number;
   sheetName: string = "";
   sheetToken!: string;
@@ -74,6 +76,11 @@ export class EmbedSdkComponent {
   }
 
   ngOnInit(){
+    if(this.embedType === 'embed-project'){
+      this.isProjectSDK = true;
+      this.isDashboardSDK = false;
+      this.isSheetSDK = false;
+    }
     this.getAppDetails();
     if(this.isDashboardSDK){
       this.getDashboardsList();
@@ -147,23 +154,53 @@ export class EmbedSdkComponent {
   `;
   }
 
+  setProjectScriptData(){
+    this.scriptContent = `
+    <script src="https://cdn.jsdelivr.net/gh/Analytify-dev/Analytify-Angular@v2.2.0/public/analytify-sdk.js"></script>
+
+    <div id="dashboard-container"></div>
+    <script>
+      const analytify = AnalytifySDK.init({
+        appName: '${this.userName}',
+        clientId: '${this.clientId}',
+        clientSecret: '${this.clientSecret}',
+        tokenEndpoint: 'https://api.qa.insightapps.ai/v1',
+        apiBaseUrl: '${this.apibaseurl}'
+      });
+
+      analytify.loadSdkProject({
+        container: '#dashboard-container',
+      });
+    </script>`;
+  }
+
   submitSDKKeys(){
     let payload = {
       app_name: this.userName,
       redirect_uri : this.apibaseurl,
     }
-    if(this.disableSDKName && this.isDashboardSDK){ 
+    if(this.disableSDKName && this.isDashboardSDK){
        this.submitDashboardId();
-    } else if(this.disableSDKName && this.isSheetSDK){ 
+    } else if(this.disableSDKName && this.isSheetSDK){
       this.submitSheetId();
-   } else {
+    } else if(this.disableSDKName && this.isProjectSDK){
+      this.displayScript = true;
+      this.setProjectScriptData();
+    } else {
      this.workbechService.saveSDKData(payload).subscribe({
       next: (data: any) => {
         this.clientId = data.client_id;
         this.clientSecret = data.client_secret;
         this.disableSDKName = true;
         this.showNotifier = true;
-        this.submitDashboardId();
+        if(this.isDashboardSDK){
+          this.submitDashboardId();
+        } else if(this.isSheetSDK){
+          this.submitSheetId();
+        } else if(this.isProjectSDK){
+          this.displayScript = true;
+          this.setProjectScriptData();
+        }
       },
       error: (error:any) => {
         console.log(error);


### PR DESCRIPTION
## Summary
- extend EmbedSdkComponent with `embedType` input and Embed Project logic
- use EmbedSdkComponent for both 'Embed SDK' and 'Embed Project' tabs
- remove obsolete EmbedProject component

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_b_688badbbd7f08320b6f9f04cc413feef