### PR TITLE
fix: ensure embed type passes on first selection

### DIFF
--- a/src/app/components/workbench/configure/configure.component.html
+++ b/src/app/components/workbench/configure/configure.component.html
@@ -14,7 +14,7 @@
                             <div class="nav-item btn-primary-light"><i class="fe fe-mail me-1"></i> Email Configuration</div>
                         </div> -->
 
-                         <ul ngbNav #nav="ngbNav" [(activeId)]="activeTab" class="nav-pills flex-column">
+                         <ul ngbNav #nav="ngbNav" [(activeId)]="activeTab" class="nav-pills flex-column" (navChange)="onNavChange($event)">
               <li [ngbNavItem]="'configure'" className="nav-link text-start " class="general-tab">
                 <a ngbNavLink><i class="fe fe-settings me-1"></i>OpenAI Key Configuration</a>
                 <ng-template ngbNavContent id="configure">
@@ -102,7 +102,7 @@
                 </li>
 
                 <li [ngbNavItem]="'embedsdk'" class="mt-2 general-tab">
-                    <a ngbNavLink (click)="selectedEmbedType = 'embed-sdk'"><i class="fe fe-code me-1"></i> Embed SDK</a>
+                    <a ngbNavLink><i class="fe fe-code me-1"></i> Embed SDK</a>
                     <ng-template ngbNavContent id="embedsdk">
                          <div class="card profile-card">
                             <div class="card-body">
@@ -113,7 +113,7 @@
                 </li>
 
                 <li [ngbNavItem]="'embedproject'" class="mt-2 general-tab">
-                    <a ngbNavLink (click)="selectedEmbedType = 'embed-project'"><i class="fe fe-code me-1"></i> Embed Project</a>
+                    <a ngbNavLink><i class="fe fe-code me-1"></i> Embed Project</a>
                     <ng-template ngbNavContent id="embedproject">
                          <div class="card profile-card">
                             <div class="card-body">

--- a/src/app/components/workbench/configure/configure.component.ts
+++ b/src/app/components/workbench/configure/configure.component.ts
@@ -7,7 +7,7 @@ import { CommonModule } from '@angular/common';
 import { SharedModule } from '../../../shared/sharedmodule';
 // import { data } from '../../charts/echarts/echarts';
 import Swal from 'sweetalert2';
-import { NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
+import { NgbModal, NgbModule, NgbNavChangeEvent } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { ToastrService } from 'ngx-toastr';
 import { UsersDashboardComponent } from '../users-dashboard/users-dashboard.component';
@@ -123,6 +123,14 @@ ngOnInit(): void {
     // if(this.activateEmailTab){
     //   this.getdashboardDetails()
     // }
+}
+
+onNavChange(event: NgbNavChangeEvent) {
+  if (event.nextId === 'embedsdk') {
+    this.selectedEmbedType = 'embed-sdk';
+  } else if (event.nextId === 'embedproject') {
+    this.selectedEmbedType = 'embed-project';
+  }
 }
 selectedDatasource: any = null;
 selectedDashboard: any = null;


### PR DESCRIPTION
## Summary
- fix selected embed type when switching tabs by handling navChange event
- remove click handlers relying on ngbNavLink

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: ERESOLVE unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6891e5b8a9b48320b3a20253bbe7d8ff