### PR TITLE
feat: improve embed OAuth handling

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -173,22 +173,34 @@ export class WorkbenchService {
   }
 
   //Quickbooks
-  connectQuickBooks(){
+  connectQuickBooks(embedMode: boolean = false){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];
-    return this.http.get<any>(`${environment.apiUrl}/quickbooks/`+this.accessToken);
+    let url = `${environment.apiUrl}/quickbooks/`+this.accessToken;
+    if (embedMode) {
+      url += '?embedMode=true';
+    }
+    return this.http.get<any>(url);
   }
   //salesforce
-  connectSalesforce(){
+  connectSalesforce(embedMode: boolean = false){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];
-    return this.http.get<any>(`${environment.apiUrl}/salesforce/`+this.accessToken);
+    let url = `${environment.apiUrl}/salesforce/`+this.accessToken;
+    if (embedMode) {
+      url += '?embedMode=true';
+    }
+    return this.http.get<any>(url);
   }
 
-  connectGoogleSheets(){
+  connectGoogleSheets(embedMode: boolean = false){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];
-    return this.http.get<any>(`${environment.apiUrl}/auth/google/`+this.accessToken);
+    let url = `${environment.apiUrl}/auth/google/`+this.accessToken;
+    if (embedMode) {
+      url += '?embedMode=true';
+    }
+    return this.http.get<any>(url);
   }
   getGoogleSheetsDetails(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -99,6 +99,7 @@ export class WorkbenchComponent implements OnInit{
   selectedHirchyIdCrsDb:string | null = null;
 
   iscrossDbSelect = false;
+  isEmbedMode: boolean = localStorage.getItem('embedMode') === 'true';
   primaryHierachyId:any;
   canUploadExcel = false;
   canUploadCsv = false;
@@ -1622,19 +1623,30 @@ export class WorkbenchComponent implements OnInit{
       }});
     }
 
+    private openAuthUrl(url: string): void {
+      if (this.isEmbedMode) {
+        window.top?.open(url, '_blank');
+      } else {
+        this.document.location.href = url;
+      }
+    }
+
     hubspotSignIn(){
-      const obj = {
+      const obj: any = {
         "client_id": this.hubspotClientId,
         "client_secret": this.hubspotClientSecret,
         "redirect_uri": this.hubspotRedirectURL,
         "display_name": this.displayName,
         "scopes": this.selectedHubspotScopes
+      };
+      if (this.isEmbedMode) {
+        obj.state = 'embedMode=true';
       }
       this.workbechService.hubspotConnection(obj).subscribe({next:(data)=>{
           if(data){
             localStorage.setItem('hubspotHierarchyId', data.hierarchy_id);
             this.modalService.dismissAll();
-            this.document.location.href = data.authorisation_url;
+            this.openAuthUrl(data.authorisation_url);
           }
         },
         error:(error)=>{
@@ -2131,13 +2143,13 @@ export class WorkbenchComponent implements OnInit{
           confirmButtonText: 'Ok'
         }).then((result)=>{
           if(result.isConfirmed){
-            this.workbechService.connectQuickBooks()
+            this.workbechService.connectQuickBooks(this.isEmbedMode)
             .subscribe(
               {
                 next: (data) => {
                   console.log(data);
                   // this.routeUrl = data.redirection_url
-                  this.document.location.href = data.redirection_url;
+                  this.openAuthUrl(data.redirection_url);
                   this.loaderService.show();
                 },
                 error: (error) => {
@@ -2145,7 +2157,7 @@ export class WorkbenchComponent implements OnInit{
                 }
               }
             )
-          }}) 
+          }})
       }
       connectSalesforce(){
         Swal.fire({
@@ -2158,20 +2170,20 @@ export class WorkbenchComponent implements OnInit{
         confirmButtonText: 'Ok'
       }).then((result)=>{
         if(result.isConfirmed){
-          this.workbechService.connectSalesforce()
+          this.workbechService.connectSalesforce(this.isEmbedMode)
           .subscribe(
             {
               next: (data) => {
                 console.log(data);
                 // this.routeUrl = data.redirection_url
-                this.document.location.href = data.redirection_url;
+                this.openAuthUrl(data.redirection_url);
               },
               error: (error) => {
                 console.log(error);
               }
             }
           )
-        }}) 
+        }})
       }
 
       connectxAmplify() {
@@ -2217,13 +2229,13 @@ connectGoogleSheets(){
     confirmButtonText: 'Ok'
   }).then((result)=>{
     if(result.isConfirmed){
-      this.workbechService.connectGoogleSheets()
+      this.workbechService.connectGoogleSheets(this.isEmbedMode)
       .subscribe(
         {
           next: (data) => {
             console.log(data);
             // this.routeUrl = data.redirection_url
-            this.document.location.href = data.redirection_url;
+            this.openAuthUrl(data.redirection_url);
             this.loaderService.show();
           },
           error: (error) => {
@@ -2231,7 +2243,7 @@ connectGoogleSheets(){
           }
         }
       )
-    }}) 
+    }})
 }
 
     deleteDbConnection(id:any){

--- a/src/app/embed/sdk-auth.guard.ts
+++ b/src/app/embed/sdk-auth.guard.ts
@@ -8,10 +8,13 @@ export const sdkAuthGuard: CanActivateFn = (route) => {
     const token = route.queryParamMap.get('token');
     if (token) {
       localStorage.setItem('currentUser', JSON.stringify({ Token: token }));
+      localStorage.setItem('embedMode', 'true');
       return true;
     }
+    localStorage.removeItem('embedMode');
     router.navigate(['authentication/login']);
     return false;
   }
+  localStorage.setItem('embedMode', 'true');
   return true;
 };


### PR DESCRIPTION
## Summary
- ensure embed SDK routes mark embed mode
- adjust integration services to accept embed flag
- open OAuth URLs in parent window for embed mode

## Testing
- `npm test` *(fails: ng: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_b_6892e5f41bb48320a781ad3dabfafe75