### PR TITLE
feat: add dashboard build lock

### DIFF
--- a/src/app/components/workbench/genie-aiq-dashboard/genie-aiq-dashboard.component.ts
+++ b/src/app/components/workbench/genie-aiq-dashboard/genie-aiq-dashboard.component.ts
@@ -218,8 +218,9 @@ isInsightSelected(insight: any): boolean {
      this.workbechService.getDashbaordSuggestions(payload).subscribe({
       next:(data)=>{
       console.log(data);
-      this.templateDashboardService.buildSampleGieneAiqDashbaord(this.hierarchyId.hierarchy_id, data);
-      this.step = 3;
+      this.templateDashboardService.buildSampleGieneAiqDashbaordOnce(this.hierarchyId.hierarchy_id, data).subscribe(() => {
+        this.step = 3;
+      });
       },
       error:(error)=>{
         console.log(error);

--- a/src/app/services/template-dashboard.service.spec.ts
+++ b/src/app/services/template-dashboard.service.spec.ts
@@ -1,16 +1,49 @@
 import { TestBed } from '@angular/core/testing';
-
+import { of } from 'rxjs';
+import { Router } from '@angular/router';
+import { ToastrService } from 'ngx-toastr';
+import { WorkbenchService } from '../components/workbench/workbench.service';
 import { TemplateDashboardService } from './template-dashboard.service';
 
 describe('TemplateDashboardService', () => {
   let service: TemplateDashboardService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    const workbenchStub = {
+      buildSampleImmybotDashboard: jasmine.createSpy('buildSampleImmybotDashboard').and.returnValue(of({}))
+    };
+    TestBed.configureTestingModule({
+      providers: [
+        TemplateDashboardService,
+        { provide: WorkbenchService, useValue: workbenchStub },
+        { provide: Router, useValue: {} },
+        { provide: ToastrService, useValue: { error: () => {} } }
+      ]
+    });
     service = TestBed.inject(TemplateDashboardService);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('withBuildLock prevents double build', (done) => {
+    (service as any).withBuildLock('test', () => of(1));
+    const second = (service as any).withBuildLock('test', () => of(2));
+    let emitted = false;
+    second.subscribe({
+      next: () => { emitted = true; },
+      complete: () => {
+        expect(emitted).toBeFalse();
+        done();
+      }
+    });
+  });
+
+  it('buildSampleGieneAiqDashbaordOnce caches result', () => {
+    const wb = TestBed.inject(WorkbenchService) as any;
+    service.buildSampleGieneAiqDashbaordOnce(1).subscribe();
+    service.buildSampleGieneAiqDashbaordOnce(1).subscribe();
+    expect(wb.buildSampleImmybotDashboard).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ViewContainerRef } from '@angular/core';
 import { Router } from '@angular/router';
-import { forkJoin, switchMap } from 'rxjs';
+import { forkJoin, switchMap, Observable, of, tap, shareReplay, EMPTY, finalize } from 'rxjs';
 import { InsightEchartComponent } from '../components/workbench/insight-echart/insight-echart.component';
 import { WorkbenchService } from '../components/workbench/workbench.service';
 import { uuidv4 } from '@firebase/util';
@@ -17,6 +17,8 @@ interface TableRow {
   providedIn: 'root'
 })
 export class TemplateDashboardService {
+  private building = new Set<string>();
+  private cache = new Map<string, Observable<any>>();
   customizeOptions = {GridColor
     : 
     "#089ffc",
@@ -316,6 +318,14 @@ export class TemplateDashboardService {
   dashboardQuerySetIds: number[]=[];
   sheetsData: any;
   constructor(private workbechService:WorkbenchService,private router:Router,private toasterservice:ToastrService) { }
+
+  private withBuildLock<T>(key: string, work: () => Observable<T>): Observable<T> {
+    if (this.building.has(key)) {
+      return EMPTY;
+    }
+    this.building.add(key);
+    return work().pipe(finalize(() => this.building.delete(key)));
+  }
 
   buildDashboardTransfer(container: ViewContainerRef,responesData : any){
     const componentRef =container.createComponent(SheetsComponent);
@@ -639,7 +649,7 @@ export class TemplateDashboardService {
       });
     }
   }
-   buildSampleGieneAiqDashbaord(container: ViewContainerRef, databaseId: any, responceData?: any) {
+  buildSampleGieneAiqDashbaord(container: ViewContainerRef, databaseId: any, responceData?: any) {
     const componentRef = container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;
 
@@ -671,6 +681,17 @@ export class TemplateDashboardService {
     } else {
      return
     }
+  }
+
+  buildSampleGieneAiqDashbaordOnce(databaseId: any, responceData?: any): Observable<any> {
+    const key = `genieaiq:${databaseId}`;
+    if (this.cache.has(key)) {
+      return this.cache.get(key)!;
+    }
+    const source$ = responceData ? of(responceData) : this.workbechService.buildSampleImmybotDashboard(databaseId);
+    const work$ = this.withBuildLock(key, () => source$.pipe(shareReplay(1)));
+    this.cache.set(key, work$);
+    return work$;
   }
   buildDashboardResponseData(responce: any){
     let dashboardData: any[] = [];


### PR DESCRIPTION
## Summary
- add build lock and caching to TemplateDashboardService to prevent re-entrant dashboard generation
- expose buildSampleGieneAiqDashbaordOnce for data-first dashboard building
- invoke new data-first build from GenieAiqDashboardComponent and add unit tests

## Testing
- `npm test -- --watch=false` *(fails: ng: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*

------
https://chatgpt.com/codex/tasks/task_b_6898a530d7248320813244e3084d0a4d