### PR TITLE
feat: add glassmorphism theme

### DIFF
--- a/src/app/services/custom-theme.service.ts
+++ b/src/app/services/custom-theme.service.ts
@@ -8,6 +8,7 @@ export class CustomThemeService {
 
   currentTheme : any;
   apiCustomTheme : any;
+  glassBackgroundUrl: string | null = null;
 
   constructor() { }
 
@@ -40,5 +41,19 @@ export class CustomThemeService {
       return this.currentTheme;
     }
     return JSON.parse(localStorage.getItem("customTheme")!);
+  }
+
+  setGlassBackground(url: string){
+    this.glassBackgroundUrl = url;
+    localStorage.setItem('glassBgImage', url);
+    document.documentElement.style.setProperty('--glass-bg-image', `url('${url}')`);
+  }
+
+  getGlassBackground(): string | null{
+    if(this.glassBackgroundUrl){
+      return this.glassBackgroundUrl;
+    }
+    const stored = localStorage.getItem('glassBgImage');
+    return stored ? stored : null;
   }
 }

--- a/src/app/shared/layout-components/switcher/switcher.component.html
+++ b/src/app/shared/layout-components/switcher/switcher.component.html
@@ -21,8 +21,7 @@
                                             Light
                                         </label>
                                         <input class="form-check-input" type="radio" name="theme-style" id="switcher-light-theme"
-                                        (click)="themeChange('light','light')" [checked]="localdata['insightappsdarktheme']!='dark'"
-                                            >
+                                        (click)="themeChange('light','light')" [checked]="localdata['insightappsdarktheme']=='light' || !localdata['insightappsdarktheme']">
                                     </div>
                                 </div>
                                 <div class="col-4">
@@ -34,6 +33,20 @@
                                         (click)="themeChange('dark','dark')" [checked]="localdata['insightappsdarktheme']=='dark'">
                                     </div>
                                 </div>
+                                <div class="col-4">
+                                    <div class="form-check switch-select">
+                                        <label class="form-check-label" for="switcher-glass-theme">
+                                            Glassmorphism
+                                        </label>
+                                        <input class="form-check-input" type="radio" name="theme-style" id="switcher-glass-theme"
+                                        (click)="selectGlass()" [checked]="localdata['insightappsdarktheme']=='glass'">
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="w-100 mt-2" *ngIf="isGlass">
+                                <input type="file" accept="image/*" (change)="onGlassFileChange($event)">
+                                <img *ngIf="glassPreview" [src]="glassPreview" class="img-fluid mt-2"/>
+                                <button class="btn btn-primary w-100 mt-2" (click)="applyGlassTheme()">Apply</button>
                             </div>
                         </div>
                         <div class="">

--- a/src/app/shared/layout-components/switcher/switcher.component.spec.ts
+++ b/src/app/shared/layout-components/switcher/switcher.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { SwitcherComponent } from './switcher.component';
+import { NavService } from '../../services/navservice';
+import { WorkbenchService } from '../../../components/workbench/workbench.service';
+import { SharedService } from '../../services/shared.service';
+import { DefaultColorPickerService } from '../../../services/default-color-picker.service';
+import { ToastrService } from 'ngx-toastr';
+import { CustomThemeService } from '../../../services/custom-theme.service';
 
 describe('SwitcherComponent', () => {
   let component: SwitcherComponent;
@@ -8,8 +13,16 @@ describe('SwitcherComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      declarations: [SwitcherComponent]
-    });
+      declarations: [SwitcherComponent],
+      providers: [
+        { provide: NavService, useValue: {} },
+        { provide: WorkbenchService, useValue: { setChartType: () => ({ subscribe: () => {} }), saveThemes: () => ({ subscribe: () => {} }) } },
+        { provide: SharedService, useValue: { setValue: () => {} } },
+        { provide: DefaultColorPickerService, useValue: { setColor: () => {} } },
+        { provide: ToastrService, useValue: { success: () => {}, error: () => {} } },
+        { provide: CustomThemeService, useValue: { getGlassBackground: () => null, setGlassBackground: () => {}, setThemeVariable: () => {}, getCurrentTheme: () => ({}), setApiCustomTheme: () => {}, setCurrentTheme: () => {} } }
+      ]
+    }).compileComponents();
     fixture = TestBed.createComponent(SwitcherComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/src/app/shared/layout-components/switcher/switcher.component.ts
+++ b/src/app/shared/layout-components/switcher/switcher.component.ts
@@ -32,6 +32,8 @@ export class SwitcherComponent {
 
   }
   body = document.querySelector('body');
+  isGlass: boolean = false;
+  glassPreview: string | null = null;
 
   SwitcherClose(){
   //   if (document.querySelector(".offcanvas-end")?.classList.contains("show")) {
@@ -44,6 +46,27 @@ export class SwitcherComponent {
     document.querySelector("body")!.classList.remove("padding-right:4px");
     document.querySelector(".switcher-backdrop")?.classList.remove("d-block");
     document.querySelector(".switcher-backdrop")?.classList.add("d-none");
+  }
+  selectGlass(){
+    this.isGlass = true;
+    const existing = this.themeService.getGlassBackground();
+    if(existing){
+      this.glassPreview = existing;
+    }
+  }
+
+  onGlassFileChange(event: any){
+    const file = event.target.files && event.target.files[0];
+    if(file){
+      this.glassPreview = URL.createObjectURL(file);
+    }
+  }
+
+  applyGlassTheme(){
+    if(this.glassPreview){
+      this.themeService.setGlassBackground(this.glassPreview);
+      this.themeChange('glass','dark');
+    }
   }
   themeChange(type: string, type1: string) {
     const htmlElement =
@@ -60,6 +83,9 @@ export class SwitcherComponent {
     );
     this.renderer.setAttribute(htmlElement, 'data-header-styles', type1);
     localStorage.setItem('insightappsHeader', type1);
+    if(type !== 'glass'){
+      this.isGlass = false;
+    }
     if (localStorage.getItem('insightappsdarktheme') == 'light') {
       localStorage.removeItem("insightapps-background-mode-body");
       localStorage.removeItem("insightapps-background-mode-dark");
@@ -421,6 +447,10 @@ export class SwitcherComponent {
     switcher.localStorageBackUp();
     this.closeMenu(localStorage.getItem('insightappsMenus'));
     this.setChartType();
+    if(localStorage.getItem('insightappsdarktheme') === 'glass'){
+      this.isGlass = true;
+      this.glassPreview = this.themeService.getGlassBackground();
+    }
   }
 
   public localdata = localStorage;

--- a/src/app/shared/layout-components/switcher/switcher.ts
+++ b/src/app/shared/layout-components/switcher/switcher.ts
@@ -116,6 +116,10 @@ export function dynamicBgTrasnsparentPrimaryColor(
 
 export function localStorageBackUp() {
   let html = document.querySelector('html');
+  if (localStorage.getItem('glassBgImage')) {
+    const img: any = localStorage.getItem('glassBgImage');
+    html?.style.setProperty('--glass-bg-image', `url('${img}')`);
+  }
   if (localStorage.getItem('data-header-styles') == 'dark') {
     if (html?.setAttribute('data-theme-mode', 'dark')) {
       const light = document.getElementById(

--- a/src/assets/scss/_variables.scss
+++ b/src/assets/scss/_variables.scss
@@ -43,6 +43,16 @@
 	--input-border: 									#e9edf6;
 	--form-control-bg: 									#ffffff;
 	--fixed-white: 									    #ffffff;
+        --glass-blur: 14px;
+        --glass-opacity: 0.6;
+        --glass-border: 1px;
+        --glass-border-color: rgba(255, 255, 255, 0.25);
+        --glass-shadow: 0 10px 30px rgba(0,0,0,0.2);
+        --glass-overlay: linear-gradient(rgba(0,0,0,0.15), rgba(0,0,0,0.15));
+        --glass-bg-image: none;
+        --glass-bg-position: center center;
+        --glass-bg-size: cover;
+        --glass-bg-attachment: fixed;
     --breakpoint-sm: 576px;
     --breakpoint-md: 768px;
     --breakpoint-lg: 992px;
@@ -268,6 +278,45 @@ $black-9:												var(--black-9);
 	--black-8:											rgba(255,255,255,0.8);
 	--black-9:											rgba(255,255,255,0.9);
     
+}
+[data-theme-mode="glass"] {
+  body,
+  .app-root {
+    background-image: var(--glass-bg-image), var(--glass-overlay);
+    background-position: var(--glass-bg-position);
+    background-size: var(--glass-bg-size);
+    background-attachment: var(--glass-bg-attachment);
+    background-repeat: no-repeat;
+    background-color: #000;
+  }
+  --default-text-color: #f5f7fa;
+  --text-muted: rgba(245,247,250,0.8);
+  --heading-color: #ffffff;
+  --link-color: #e2e8ff;
+  --surface-bg: rgba(255,255,255, var(--glass-opacity));
+  --surface-border: var(--glass-border) solid var(--glass-border-color);
+  --surface-shadow: var(--glass-shadow);
+  --custom-white: var(--surface-bg);
+  --default-background: var(--surface-bg);
+  --menu-bg: var(--surface-bg);
+  --header-bg: var(--surface-bg);
+  --menu-border-color: var(--glass-border-color);
+  --header-border-color: var(--glass-border-color);
+  --input-border: var(--glass-border-color);
+  --form-control-bg: var(--surface-bg);
+}
+
+[data-theme-mode="glass"] .glass-panel,
+[data-theme-mode="glass"] .card,
+[data-theme-mode="glass"] .modal-content,
+[data-theme-mode="glass"] .offcanvas,
+[data-theme-mode="glass"] .app-header,
+[data-theme-mode="glass"] .app-sidebar {
+  background: var(--surface-bg);
+  border: var(--surface-border);
+  box-shadow: var(--surface-shadow);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
 }
 
 /*float variables*/


### PR DESCRIPTION
## Summary
- expand theme variables with glassmorphism tokens and surface styling
- enable glass theme selection with image picker via switcher component
- persist glass background and theme choice through custom theme service and localStorage

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899b9fb4f0c83209604e9f88a9d831c