### PR TITLE
feat: add Gemini integration

### DIFF
--- a/src/app/components/workbench/landingpage/landingpage.component.html
+++ b/src/app/components/workbench/landingpage/landingpage.component.html
@@ -306,14 +306,19 @@
                                                 src="./assets/images/icons/hubspotlogo.png"
                                                 alt="Hubspot"
                                                 class="card-img w-5 h-5 icon-bounce" />
-                                                <img *ngIf="database.server_type === 'DEEPSEEK'"
+                                            <img *ngIf="database.server_type === 'DEEPSEEK'"
                                                 src="./assets/images/icons/deepseek.svg"
                                                 alt="DeepSeek"
                                                 class="card-img w-5 h-5 icon-bounce" />
-                                                
+
                                             <img *ngIf="database.server_type === 'OPEN_AI'"
                                                 src="https://logo.clearbit.com/openai.com"
                                                 alt="OpenAI"
+                                                class="card-img w-5 h-5 icon-bounce" />
+
+                                            <img *ngIf="database.server_type === 'GEMINI'"
+                                                src="/assets/images/Db_server_images/gemini-color.svg"
+                                                alt="Gemini"
                                                 class="card-img w-5 h-5 icon-bounce" />
                                                 
                                             <img *ngIf="database.server_type === 'MYSQL'"
@@ -752,6 +757,11 @@
                                             <img *ngIf="savedQuery.server_type === 'OPEN_AI'"
                                                 src="https://logo.clearbit.com/openai.com"
                                                 alt="OpenAI"
+                                                class="avatar-radius icon-pulse w-5 h-5">
+
+                                            <img *ngIf="savedQuery.server_type === 'GEMINI'"
+                                                src="/assets/images/Db_server_images/gemini-color.svg"
+                                                alt="Gemini"
                                                 class="avatar-radius icon-pulse w-5 h-5">
 
                                             <img *ngIf="savedQuery.server_type === 'MYSQL'"

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -121,6 +121,21 @@ export class WorkbenchService {
     this.accessToken = JSON.parse( currentUser! )['Token'];
     return this.http.post<any>(`${environment.apiUrl}/deepseek_authentication/`+this.accessToken,obj);
   }
+  geminiConnection(obj:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.post<any>(`${environment.apiUrl}/gemini_authentication/`+this.accessToken,obj);
+  }
+  getGeminiConnection(id:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.get<any>(`${environment.apiUrl}/gemini_authentication/`+id+'/'+this.accessToken);
+  }
+  deleteGeminiConnection(id:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.delete<any>(`${environment.apiUrl}/gemini_authentication/`+id+'/'+this.accessToken);
+  }
   hubspotConnection(obj:any){
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];
@@ -163,6 +178,12 @@ export class WorkbenchService {
     const currentUser = localStorage.getItem( 'currentUser' );
     this.accessToken = JSON.parse( currentUser! )['Token'];
     return this.http.put<any>(`${environment.apiUrl}/deepseek_authentication/`+this.accessToken,obj);
+  }
+
+  geminiConnectionUpdate(obj:any){
+    const currentUser = localStorage.getItem( 'currentUser' );
+    this.accessToken = JSON.parse( currentUser! )['Token'];
+    return this.http.put<any>(`${environment.apiUrl}/gemini_authentication/`+this.accessToken,obj);
   }
 
   ninjaRMMConnectionUpdate(obj:any){

--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -211,6 +211,17 @@
                   <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. DeepSeek" (input)="displayNameIntegrationConditionError()">
                 </div>
               </form>
+            } @else if(databaseType == 'gemini') {
+              <form>
+                <div class="mb-2">
+                  <label [ngClass]="{'error-label': geminiKeyError}" class="col-form-label">Gemini Key <span class="text-danger ms-1">*</span></label>
+                  <input [ngClass]="{'error-input': geminiKeyError}" type="text" class="form-control" [(ngModel)]="geminiKey" [ngModelOptions]="{standalone: true}" (input)="geminiKeyInputError()">
+                </div>
+                <div class="mb-2">
+                  <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1" >*</span></label>
+                  <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" placeholder="e.g. Gemini" (input)="displayNameIntegrationConditionError()">
+                </div>
+              </form>
             }@else if(databaseType == 'google_analytics') {
               <form>
                 <div class="mb-2">
@@ -372,6 +383,9 @@
             } @else if(databaseType == 'deepseek') {
               <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="modal.close('cross click')">Close</button>
               <button type="button" class="btn btn-primary" (click)="deepSeekUpdate()" [disabled]="(deepSeekKeyError || displayNameError) || !(deepSeekKey && displayName)">Update</button>
+            } @else if(databaseType == 'gemini') {
+              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal" (click)="modal.close('cross click')">Close</button>
+              <button type="button" class="btn btn-primary" (click)="geminiUpdate()" [disabled]="(geminiKeyError || displayNameError) || !(geminiKey && displayName)">Update</button>
             } @else if(databaseType == 'google_analytics') {
               <button type="button" class="btn btn-secondary" (click)="modal.close('cross click')">Close</button>
               <button type="button" class="btn btn-primary"
@@ -534,6 +548,9 @@
                       <td *ngIf="database.server_type === 'DEEPSEEK'">
                         <img alt="product" src="./assets/images/icons/deepseek.svg" class="w-5 h-5 border me-2">{{database.server_type}}
                       </td>
+                      <td *ngIf="database.server_type === 'GEMINI'">
+                        <img alt="product" src="/assets/images/Db_server_images/gemini-color.svg" class="w-5 h-5 border me-2">{{database.server_type}}
+                      </td>
                       <td *ngIf="database.server_type === 'GOOGLE_ANALYTICS'">
                         <img alt="product" src="./assets/images/icons/google-anaytics.jpg" class="w-5 h-5 border me-2">{{database.server_type}}
                       </td>
@@ -547,7 +564,7 @@
                                   aria-label="anchor" (click)="editDbDetails(database.hierarchy_id);editDbConnectionModal(EditDbCon);"
                                   class="btn btn-icon btn-sm btn-info-light btn-wave waves-effect waves-light">
                                   <i class="ri-edit-line" ngbTooltip="Edit database"></i></button>
-                                <button *ngIf="!database.is_cross_db && (database.server_type === 'CONNECTWISE' || database.server_type === 'SHOPIFY' || database.server_type === 'HALOPS' || database.server_type === 'OPEN_AI' || database.server_type === 'HUBSPOT' || database.server_type === 'NINJA'
+                                <button *ngIf="!database.is_cross_db && (database.server_type === 'CONNECTWISE' || database.server_type === 'SHOPIFY' || database.server_type === 'HALOPS' || database.server_type === 'OPEN_AI' || database.server_type === 'HUBSPOT' || database.server_type === 'NINJA' || database.server_type === 'GEMINI'
                                 || database.server_type === 'IMMYBOT' || database.server_type === 'QUICKBOOKS' || database.server_type === 'SALESFORCE' || database.server_type === 'TALLY' || database.server_type === 'PAX8' || database.server_type === 'BAMBOOHR')" class="btn btn-icon btn-sm btn-primary-light btn-wave waves-effect waves-light" (click)="smartDashboardFromConnection(database)">
                                   <i class="fe fe-zap" ngbTooltip="Smart Dashboard"></i>
                                 </button>
@@ -639,6 +656,8 @@
                                               <img src="https://logo.clearbit.com/openai.com" alt="" class="rounded-circle"></span>
                                               <span *ngIf="database.server_type === 'DEEPSEEK'" class="avatar avatar rounded-circle">
                                                 <img src="./assets/images/icons/deepseek.svg" alt="" class="rounded-circle"></span>
+                                              <span *ngIf="database.server_type === 'GEMINI'" class="avatar avatar rounded-circle">
+                                                <img src="/assets/images/Db_server_images/gemini-color.svg" alt="" class="rounded-circle"></span>
                                             <span *ngIf="database.server_type === 'CONNECTWISE'" class="avatar avatar rounded-circle">
                                               <img src="./assets/images/icons/connectwise-icon.png" alt="" class="rounded-circle"></span>
                                               <span *ngIf="database.server_type === 'HALOPS'" class="avatar avatar rounded-circle">
@@ -686,7 +705,7 @@
                             <app-insights-button *ngIf="!(database.server_type === 'CSV' || database.server_type ==='EXCEL' || database.server_type ==='SQLITE' || database.server_type ==='QUICKBOOKS' || database.server_type ==='SALESFORCE' || database.server_type ==='GOOGLE_SHEETS' ||database.server_type ==='HUBSPOT')" [buttonName]="' Edit'" [classesList]="'dropdown-item'" [previledgeId]="2" [isBtn]="false"
                               [tabIndex]="0" (btnClickEvent)="editDbDetails(database.hierarchy_id);editDbConnectionModal(EditDbCon);"
                               [faIconList]="'fe fe-edit me-2 d-inline-flex'" [isIcon]="true"></app-insights-button>
-                            <a *ngIf="!database.is_cross_db && (database.server_type === 'CONNECTWISE' || database.server_type === 'SHOPIFY' || database.server_type === 'HALOPS' || database.server_type === 'OPEN_AI' || database.server_type === 'HUBSPOT' || database.server_type === 'NINJA'
+                            <a *ngIf="!database.is_cross_db && (database.server_type === 'CONNECTWISE' || database.server_type === 'SHOPIFY' || database.server_type === 'HALOPS' || database.server_type === 'OPEN_AI' || database.server_type === 'HUBSPOT' || database.server_type === 'NINJA' || database.server_type === 'GEMINI'
                             || database.server_type === 'IMMYBOT' || database.server_type === 'QUICKBOOKS' || database.server_type === 'SALESFORCE' || database.server_type === 'TALLY' || database.server_type === 'PAX8' || database.server_type === 'BAMBOOHR')" class="dropdown-item" (click)="smartDashboardFromConnection(database)"><i class='fe fe-zap me-2 d-inline-flex'></i> Smart Dashboard</a>
                             <a *ngIf="database?.transformation && !database.is_cross_db" class="dropdown-item" (click)="goToTransformationLayer(database?.hierarchy_id)" ngbTooltip="Edit Transformation"><img src="./assets/images/icons/transformation_blue.png" class="avatar-databse-sm d-inline-flex me-2"> Edit Transforma...</a>
                             <a *ngIf="(database.server_type === 'CSV' || database.server_type ==='EXCEL')" class="dropdown-item" (click)="fileInput.click()" ><input type="file" (change)="database.server_type === 'CSV' ? uploadfileCsv($event,'replace',database) : uploadfileExcel($event,'replace',database)" [attr.accept]="database.server_type === 'CSV' ? '.csv' : '.xlsx, .xls'" #fileInput style="display: none;" /><i class="fe fe-repeat"></i> Replace</a>
@@ -1850,6 +1869,53 @@
           </div>
         }
 
+        @if(openGeminiForm){
+          <div class="main-container container-fluid px-4 TopHeader">
+            <div class="row">
+              <div class="col-md-12 col-xl-6 p-1 mb-0">
+                <div class="card Relational-database-height">
+                  <div class="card-header">
+                    <h4 class="card-title">Connect To Gemini</h4>
+                  </div>
+                  <div class="card-body">
+                    <form>
+                      <div class="form-group">
+                        <label [ngClass]="{'error-label': geminiKeyError}" class="col-form-label">Gemini Key <span class="text-danger ms-1">*</span></label>
+                        <input [ngClass]="{'error-input': geminiKeyError}" type="text" class="form-control" [(ngModel)]="geminiKey" [ngModelOptions]="{standalone: true}" (input)="geminiKeyInputError()">
+                      </div>
+                      <div class="form-group">
+                        <label [ngClass]="{'error-label': displayNameError}" class="col-form-label">Display Name <span class="text-danger ms-1">*</span></label>
+                        <input [ngClass]="{'error-input': displayNameError}" type="text" class="form-control" [(ngModel)]="displayName" [ngModelOptions]="{standalone: true}" autocomplete="new-myname" (input)="displayNameIntegrationConditionError()">
+                      </div>
+                      <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" (click)="datasourceSwitchUI ? gotoDashboardWithoutSwitch() : gotoNewConnections()">Close</button>
+                        <button type="button" class="btn btn-primary" (click)="geminiSignIn()" [disabled]="(geminiKeyError || displayNameError) || !(geminiKey && displayName)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+                      </div>
+                    </form>
+                  </div>
+                </div>
+              </div>
+              <div class="col-md-12 col-xl-6 p-1 mb-0">
+                <div class="card user-card border Relational-database-height">
+                  <div class="user-image">
+                    <span class="avatar w-20 h-20 rounded-circle mb-2 user-image-outline">
+                      <img src="/assets/images/Db_server_images/gemini-color.svg" alt="" class="rounded-circle bg-white user-image-border-color">
+                    </span>
+                  </div>
+                  <div class="card-body server-content-card">
+                    <ul class="">
+                      <li><span class="mt-1">Gemini integration allows access to advanced language models for generating insights and automations.</span></li>
+                      <li><h6 class=" mt-3"><strong>Inputs to connect</strong></h6></li>
+                      <li><span class="mb-0"><strong>Gemini Key:</strong> API key from your Gemini account.</span></li>
+                      <li><span class="mb-0"><strong>Display Name:</strong> Friendly name to identify this connection.</span></li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        }
+
         @if(openOracleForm){
         <div class="main-container container-fluid px-4 TopHeader">
           <div class="row">
@@ -2545,28 +2611,28 @@
                         </div>
                       </div> -->
                     <div class="database-logo">
-                        <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}" (click)="!iscrossDbSelect && connectOpenAI()">
-                          <img src="https://logo.clearbit.com/openai.com"alt="Image" class="card-img">
-                        </div>
-                        <div class="logo-txt mt-2 text-center fw-600">
-                          <span>OpenAI</span>
+                      <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}" (click)="!iscrossDbSelect && connectOpenAI()">
+                        <img src="https://logo.clearbit.com/openai.com"alt="Image" class="card-img">
                       </div>
+                      <div class="logo-txt mt-2 text-center fw-600">
+                        <span>OpenAI</span>
                     </div>
-                    <div class="database-logo">
-                        <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}" (click)="!iscrossDbSelect && connectDeepSeek()">
-                          <img src="./assets/images/icons/deepseek.svg"alt="Image" class="card-img">
-                        </div>
-                        <div class="logo-txt mt-2 text-center fw-600">
-                          <span>DeepSeek</span>
+                  </div>
+                  <div class="database-logo">
+                      <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}" (click)="!iscrossDbSelect && connectDeepSeek()">
+                        <img src="./assets/images/icons/deepseek.svg"alt="Image" class="card-img">
                       </div>
+                      <div class="logo-txt mt-2 text-center fw-600">
+                        <span>DeepSeek</span>
                     </div>
+                  </div>
                     <div class="database-logo">
-                      <div class="imgcard p-4 op-4">
+                      <div class="imgcard p-4" [ngClass]="{'op-4': iscrossDbSelect}" (click)="!iscrossDbSelect && connectGemini()">
                         <img src="/assets/images/Db_server_images/gemini-color.svg"alt="Image" class="card-img">
                       </div>
                       <div class="logo-txt mt-2 text-center fw-600">
                         <span>Gemini</span>
-                    </div>        
+                    </div>
                   </div>
                 <div class="database-logo">
                   <div class="imgcard p-4 op-4">

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -67,6 +67,7 @@ export class WorkbenchComponent implements OnInit{
   openGoogleAnalyticsForm = false;
   openOpenAIForm = false;
   openDeepSeekForm = false;
+  openGeminiForm = false;
   openOracleForm = false;
   openMicrosoftSqlServerForm = false;
   openSnowflakeServerForm = false;
@@ -379,6 +380,7 @@ export class WorkbenchComponent implements OnInit{
     tallyToken = '';
     openAiKey = '';
     deepSeekKey = '';
+    geminiKey = '';
 
     googleAnalytics: {
       type: string;
@@ -1010,6 +1012,26 @@ export class WorkbenchComponent implements OnInit{
       )
 
     }
+    geminiUpdate(){
+      const obj = {
+        "gemini_key": this.geminiKey,
+        "display_name": this.displayName,
+        "hierarchy_id": this.databaseId
+      }
+      this.workbechService.geminiConnectionUpdate(obj).subscribe({next:(res)=>{
+            this.modalService.dismissAll('close');
+            if(res){
+              this.toasterservice.success('Updated Successfully','success',{ positionClass: 'toast-top-right'});
+            }
+            this.getDbConnectionList();
+          },
+          error:(error)=>{
+            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          }
+        }
+      )
+
+    }
     googleAnalyticsUpdate(){
       const g = this.googleAnalytics;
      const obj = { type: g.type,
@@ -1231,6 +1253,12 @@ export class WorkbenchComponent implements OnInit{
     this.viewNewDbs = false;
     this.emptyVariables();
   }
+  connectGemini(){
+    this.openGeminiForm = true;
+    this.databaseconnectionsList = false;
+    this.viewNewDbs = false;
+    this.emptyVariables();
+  }
   companyIdError(){
       if(this.companyId){
         this.companyIDError = false;
@@ -1389,6 +1417,13 @@ export class WorkbenchComponent implements OnInit{
         this.deepSeekKeyError = false;
       }else{
         this.deepSeekKeyError = true;
+      }
+    }
+    geminiKeyInputError(){
+      if(this.geminiKey){
+        this.geminiKeyError = false;
+      }else{
+        this.geminiKeyError = true;
       }
     }
     shopfyNameError(){
@@ -1824,6 +1859,34 @@ export class WorkbenchComponent implements OnInit{
             //     this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
             //   }
             // });
+          }
+        }
+      }, error:(error)=>{
+        this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+      }});
+    }
+
+    geminiSignIn(){
+      const obj = {
+        "gemini_key": this.geminiKey,
+        "display_name": this.displayName
+      }
+      this.workbechService.geminiConnection(obj).subscribe({next:(res)=>{
+        if(res){
+          this.toasterservice.success('Connected','success',{ positionClass: 'toast-top-right'});
+          this.databaseId = res?.hierarchy_id;
+          this.modalService.dismissAll();
+          if(!this.datasourceSwitchUI){
+            this.openGeminiForm = false;
+          }
+          const encodedId = btoa(this.databaseId.toString());
+          if(this.iscrossDbSelect){
+            this.selectedHirchyIdCrsDb = this.databaseId;
+            this.connectCrossDbs();
+          }else if(this.datasourceSwitchUI){
+            this.switchDatabase();
+          }else{
+            this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
           }
         }
       }, error:(error)=>{
@@ -2651,6 +2714,9 @@ connectGoogleSheets(){
     } else if (this.databaseType == "deepseek") {
       this.displayName = editData.display_name;
       this.deepSeekKey = editData.deepseek_key;
+    } else if (this.databaseType == "gemini") {
+      this.displayName = editData.display_name;
+      this.geminiKey = editData.gemini_key;
     }else if (this.databaseType === 'google_analytics') {
       this.googleAnalytics = {
         type: 'service_account',
@@ -2804,6 +2870,7 @@ connectGoogleSheets(){
   this.openTallyForm = false;
   this.openOpenAIForm = false;
   this.openDeepSeekForm = false;
+  this.openGeminiForm = false;
   this.openHubspotForm = false;
   this.openGoogleAnalyticsForm = false;
   this.openGoogleAnalyticsForm = false;
@@ -2828,6 +2895,8 @@ connectGoogleSheets(){
   this.openAiKeyError = false;
   this.deepSeekKey = '';
   this.deepSeekKeyError = false;
+  this.geminiKey = '';
+  this.geminiKeyError = false;
   this.ninjaRMMClientid = '';
   this.ninjaRMMClientSecret = '';
   this.selectedNinjaRMMScopes = [];
@@ -2863,6 +2932,7 @@ connectGoogleSheets(){
   tallyTokenError:boolean = false;
   openAiKeyError:boolean = false;
   deepSeekKeyError:boolean = false;
+  geminiKeyError:boolean = false;
 
   serverConditionError(){
     if(this.schemaList && this.schemaList.length > 0){
@@ -3286,6 +3356,9 @@ connectGoogleSheets(){
             this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
             break;
             case 'DEEPSEEK':
+            this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
+            break;
+          case 'GEMINI':
             this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
             break;
         }


### PR DESCRIPTION
## Summary
- add Gemini authentication API methods
- support Gemini credentials in workbench UI and connection forms
- display Gemini integrations on landing page

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a7674e1cc48320893826aed09fc17f