### PR TITLE
feat: add chart border width customization

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.html
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.html
@@ -1,7 +1,7 @@
 @if(chartType === 'bar'){
     <div class="card-body">
-        <div id="bar-chart" class="chartfit">
-            <apx-chart #barChart 
+        <div id="bar-chart" class="chartfit" [ngStyle]="chartContainerStyles">
+            <apx-chart #barChart
             [series]="chartOptions.series"
             [chart]="chartOptions.chart"
             [xaxis]="chartOptions.xaxis"
@@ -16,8 +16,8 @@
     </div>
 }  @else if(chartType === 'horizontalBar'){
     <div class="card-body">
-        <div id="horizontal-bar-chart" class="chartfit">
-            <apx-chart #horizontalBarChart 
+        <div id="horizontal-bar-chart" class="chartfit" [ngStyle]="chartContainerStyles">
+            <apx-chart #horizontalBarChart
             [series]="chartOptions.series"
             [chart]="chartOptions.chart"
             [xaxis]="chartOptions.xaxis"
@@ -208,7 +208,7 @@
         </apx-chart>
     </div>
 } @else if(chartType === 'treemap'){
-    <div id="chart">
+    <div id="chart" [ngStyle]="chartContainerStyles">
         <apx-chart #treemapchart
         [series]="chartOptions.series"
         [chart]="chartOptions.chart"

--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -51,6 +51,7 @@ export class InsightApexComponent {
   @Input() dataLabels: any;
   @Input() label : any;
   @Input() donutSize : any;
+  @Input() chartBorderWidth : any = 0;
   @Input() isDistributed : any;
   @Input() minValueGuage : any;
   @Input() gaugeDisplayMode :any;
@@ -101,6 +102,7 @@ export class InsightApexComponent {
 
   series: any[] = [];
   chartOptions: any = {};
+  chartContainerStyles: any = {};
   formattedData : any[] = [];
   guageNumber : any;
 
@@ -212,6 +214,13 @@ export class InsightApexComponent {
     }
     if((changes['displayUnits'] || changes['decimalPlaces'] || changes['prefix'] || changes['suffix'] || changes['donutDecimalPlaces']) && !changes['chartType']){
       this.updateNumberFormat();
+    }
+    if(changes['chartBorderWidth']){
+      if(['bar','horizontalBar','treemap'].includes(this.chartType)){
+        this.chartContainerStyles = this.chartBorderWidth ? { 'border': `${this.chartBorderWidth}px solid #000` } : {};
+      } else {
+        this.chartContainerStyles = {};
+      }
     }
     if(this.chartType == 'guage' && (changes['minValueGuage'] || changes['maxValueGuage'] || changes['gaugeDisplayMode'])){
       if(this.chartType == 'guage' && (changes['minValueGuage'] || changes['maxValueGuage'])){

--- a/src/app/components/workbench/insight-echart/insight-echart.component.html
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.html
@@ -1,3 +1,3 @@
 <!-- <div echarts #chartRef [options]="chartOptions" class="echart-charts"></div> -->
 
-<div id="chartContainer" class="chart-container" [style.width]="width" [style.height]="height"  #chartContainer></div>
+<div id="chartContainer" class="chart-container" [style.width]="width" [style.height]="height" [ngStyle]="chartContainerStyles"  #chartContainer></div>

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -35,6 +35,7 @@ export class InsightEchartComponent {
   @Input() dualAxisRowData:any;
   @Input() donutSize:any;
   @Input() outerRadius:any;
+  @Input() chartBorderWidth:any = 0;
   @Input() radarRowData:any;
   @Input() displayUnits:any;
   @Input() decimalPlaces:any;
@@ -96,6 +97,7 @@ export class InsightEchartComponent {
   @Input() measureColorRanges: { min: number, max: number, color: string }[] = [];
   width: string = '100%'; // Width of the chart
   height: string = '400px'; // Height of the chart
+  chartContainerStyles:any = {};
   @ViewChild('chartContainer', { static: true }) chartContainer!: ElementRef;
   private chartInstance!: echarts.ECharts;
   // @ViewChild('NgxEchartsDirective', { static: true }) chartDirective!: NgxEchartsDirective; 
@@ -2400,6 +2402,13 @@ chartInitialize(){
     }
     if(changes['donutSize'] || changes['outerRadius']){
       this.donutSizeChange();
+    }
+    if(changes['chartBorderWidth']){
+      if(['bar','horizontalBar','treemap'].includes(this.chartType)){
+        this.chartContainerStyles = this.chartBorderWidth ? { 'border': `${this.chartBorderWidth}px solid #000` } : {};
+      } else {
+        this.chartContainerStyles = {};
+      }
     }
     if(changes['isBold']){
       this.setDatalabelsFontWeight();

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2606,7 +2606,7 @@
                 [dataLabelsFontPosition]="dataLabelsFontPosition" [dataLabelsColor]="dataLabelsColor" [measureAlignment]="measureAlignment" 
                 [dimensionAlignment]="dimensionAlignment" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                 [donutDecimalPlaces]="donutDecimalPlaces" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"
-                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition"
+                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [chartBorderWidth]="chartBorderWidth"
                 [dataLabelsLineFontPosition]="dataLabelsLineFontPosition" [selectedColorScheme]="selectedColorScheme"
                 (saveOrUpdateChart)="setChartOptions($event)" (setDrilldowns)="setDrilldowns($event)"  [isMeasureDistribution]="isMeasureDistribution" [measureColorRanges]="measureColorRanges">
                 </app-insight-apex>
@@ -2624,10 +2624,10 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)"  [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
-            </div>          
+            </div>
             } @else if(horizontalBar && chartId ){
             <div class="card-body">
                 <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [chartType]="chartType" [dataLabelsFontPosition]="dataLabelsFontPosition" [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
@@ -2636,10 +2636,10 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
-            </div>          
+            </div>
             }
 
             @else if(funnel && chartId){         
@@ -2710,7 +2710,7 @@
                     <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
+                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [chartBorderWidth]="chartBorderWidth"
                     (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [leftLegend]="leftLegend" [topLegend]="topLegend" [rightLegend]="rightLegend" [bottomLegend]="bottomLegend" [legendOrient]="legendOrient" [isMeasureDistribution]="isMeasureDistribution"
                     [measureColorRanges]="measureColorRanges"></app-insight-echart>
                 </div>
@@ -5181,6 +5181,11 @@
                                                     </div>
 
                                                     
+                                                    <div *ngIf="bar || horizontalBar || treemap" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
+                                                        <label class="mb-0">Chart Border Width (px)</label>
+                                                        <input type="number" [(ngModel)]="chartBorderWidth" min="0" step="1" class="form-control" style="width: 60px;">
+                                                    </div>
+
                                                     <div *ngIf="kpi" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <label class="mb-0" for="font-size" step="1" >Font Size</label>
                                                         <input type="number" [(ngModel)]="kpiFontSize" style="width: 30%;" min="1" max="24">

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -310,6 +310,7 @@ export class SheetsComponent{
   legendsAllignment : any = 'bottom'
   donutSize:any = 50;
   outerRadius:any = 70;
+  chartBorderWidth: number = 0;
   color1:any;
   color2:any;
 
@@ -2296,6 +2297,7 @@ sheetSave(isDashboardTransfer?: boolean){
     label : this.label,
     donutSize : this.donutSize,
     outerRadius : this.outerRadius,
+    chartBorderWidth : Number(this.chartBorderWidth),
     isDistributed : this.isDistributed,
     kpiFontSize : this.kpiFontSize,
     minValueGuage : this.minValueGuage,
@@ -4371,6 +4373,7 @@ customizechangeChartPlugin() {
     this.label = data.label ?? true;
     this.donutSize = data.donutSize ?? 50;
     this.outerRadius = data.outerRadius ?? 70;
+    this.chartBorderWidth = Number(data.chartBorderWidth ?? 0);
     this.isDistributed = data.isDistributed ?? true;
     this.kpiFontSize = data.kpiFontSize ?? 3;
     this.minValueGuage = data.minValueGuage ?? 0;
@@ -4493,6 +4496,7 @@ customizechangeChartPlugin() {
     this.label = true;
     this.donutSize = 50;
     this.outerRadius = 70;
+    this.chartBorderWidth = 0;
     this.isDistributed = true;
     this.kpiFontSize = '3';
     this.minValueGuage = 0;


### PR DESCRIPTION
## Summary
- allow setting `chartBorderWidth` to draw borders around bar, horizontal bar, and treemap charts
- wire border width through sheets UI and apply styles in ApexCharts and ECharts components
- ensure `chartBorderWidth` persists by typing as a number and restoring it in `setCustomizeOptions`

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68af49a5dc0c83209e7219ecd343b378