### PR TITLE
feat: add bar corner radius control

### DIFF
--- a/src/app/components/workbench/insight-echart/insight-echart.component.html
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.html
@@ -1,3 +1,3 @@
 <!-- <div echarts #chartRef [options]="chartOptions" class="echart-charts"></div> -->
 
-<div id="chartContainer" class="chart-container" [style.width]="width" [style.height]="height" [ngStyle]="chartContainerStyles"  #chartContainer></div>
+<div id="chartContainer" class="chart-container" [style.width]="width" [style.height]="height" #chartContainer></div>

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -36,6 +36,7 @@ export class InsightEchartComponent {
   @Input() donutSize:any;
   @Input() outerRadius:any;
   @Input() chartBorderWidth:any = 0;
+  @Input() barCornerRadius = 0;
   @Input() radarRowData:any;
   @Input() displayUnits:any;
   @Input() decimalPlaces:any;
@@ -97,7 +98,6 @@ export class InsightEchartComponent {
   @Input() measureColorRanges: { min: number, max: number, color: string }[] = [];
   width: string = '100%'; // Width of the chart
   height: string = '400px'; // Height of the chart
-  chartContainerStyles:any = {};
   @ViewChild('chartContainer', { static: true }) chartContainer!: ElementRef;
   private chartInstance!: echarts.ECharts;
   // @ViewChild('NgxEchartsDirective', { static: true }) chartDirective!: NgxEchartsDirective; 
@@ -293,7 +293,7 @@ export class InsightEchartComponent {
       series: [
         {
           itemStyle: {
-            borderRadius: 5
+            borderRadius: [this.barCornerRadius, this.barCornerRadius, 0, 0]
           },
           label: { show: true,
             position: this.dataLabelsFontPosition,
@@ -422,6 +422,9 @@ horizontalBarChart(chartsColumnData?: any, chartsRowData?: any) {
       {
         type: 'bar',
         data: this.chartsRowData,
+        itemStyle: {
+          borderRadius: [0, this.barCornerRadius, this.barCornerRadius, 0]
+        },
         label: {
           show: true,
           position: this.getLabelPosition(),
@@ -1718,6 +1721,9 @@ treemapChart(chartsColumnData?: any, chartsRowData?: any){
     series: [{
       type: 'treemap',
       roam :  this.isZoom,
+      itemStyle: {
+        borderRadius: this.barCornerRadius
+      },
       data: this.chartsColumnData.map((category: any, index: number) => ({
         name: category === null ? 'null' : category,
         value: this.chartsRowData[index]
@@ -2037,7 +2043,7 @@ let barChartOptions = {
   series: [
     {
       itemStyle: {
-        borderRadius: 5
+        borderRadius: [this.barCornerRadius, this.barCornerRadius, 0, 0]
       },
       label: { show: true,
         position: this.dataLabelsFontPosition,
@@ -2403,12 +2409,26 @@ chartInitialize(){
     if(changes['donutSize'] || changes['outerRadius']){
       this.donutSizeChange();
     }
-    if(changes['chartBorderWidth']){
-      if(['bar','horizontalBar','treemap'].includes(this.chartType)){
-        this.chartContainerStyles = this.chartBorderWidth ? { 'border': `${this.chartBorderWidth}px solid #000` } : {};
-      } else {
-        this.chartContainerStyles = {};
+    if (changes['barCornerRadius'] && this.chartInstance && ['bar','horizontalBar','treemap'].includes(this.chartType)) {
+      const radius = this.barCornerRadius;
+      if (this.chartType === 'treemap') {
+        if (this.chartOptions.series?.[0]) {
+          this.chartOptions.series[0].itemStyle = {
+            ...(this.chartOptions.series[0].itemStyle || {}),
+            borderRadius: radius
+          };
+        }
+      } else if (Array.isArray(this.chartOptions.series)) {
+        this.chartOptions.series.forEach((s: any) => {
+          s.itemStyle = {
+            ...(s.itemStyle || {}),
+            borderRadius: this.chartType === 'bar'
+              ? [radius, radius, 0, 0]
+              : [0, radius, radius, 0]
+          };
+        });
       }
+      this.chartInstance.setOption(this.chartOptions, true);
     }
     if(changes['isBold']){
       this.setDatalabelsFontWeight();


### PR DESCRIPTION
## Summary
- add `barCornerRadius` input to InsightEchartComponent
- dynamically update bar, horizontal bar, and treemap corner radii
- remove chart container style binding

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular-devkit%2fbuild-angular)*

------
https://chatgpt.com/codex/tasks/task_b_68af55ff4c38832091446eb6ff1ae227