### PR TITLE
Add bar corner radius customization to sheet charts

### DIFF
--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2606,7 +2606,7 @@
                 [dataLabelsFontPosition]="dataLabelsFontPosition" [dataLabelsColor]="dataLabelsColor" [measureAlignment]="measureAlignment" 
                 [dimensionAlignment]="dimensionAlignment" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                 [donutDecimalPlaces]="donutDecimalPlaces" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"
-                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [chartBorderWidth]="chartBorderWidth"
+                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
                 [dataLabelsLineFontPosition]="dataLabelsLineFontPosition" [selectedColorScheme]="selectedColorScheme"
                 (saveOrUpdateChart)="setChartOptions($event)" (setDrilldowns)="setDrilldowns($event)"  [isMeasureDistribution]="isMeasureDistribution" [measureColorRanges]="measureColorRanges">
                 </app-insight-apex>
@@ -2624,7 +2624,7 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)"  [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
             </div>
@@ -2636,7 +2636,7 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
             </div>
@@ -2710,7 +2710,7 @@
                     <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [chartBorderWidth]="chartBorderWidth"
+                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
                     (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [leftLegend]="leftLegend" [topLegend]="topLegend" [rightLegend]="rightLegend" [bottomLegend]="bottomLegend" [legendOrient]="legendOrient" [isMeasureDistribution]="isMeasureDistribution"
                     [measureColorRanges]="measureColorRanges"></app-insight-echart>
                 </div>
@@ -5181,6 +5181,10 @@
                                                     </div>
 
                                                     
+                                                    <div *ngIf="bar || horizontalBar || treemap" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
+                                                        <label class="mb-0">Bar Corner Radius (px)</label>
+                                                        <input type="number" [(ngModel)]="barCornerRadius" min="0" step="1" class="form-control" style="width: 60px;">
+                                                    </div>
                                                     <div *ngIf="bar || horizontalBar || treemap" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <label class="mb-0">Chart Border Width (px)</label>
                                                         <input type="number" [(ngModel)]="chartBorderWidth" min="0" step="1" class="form-control" style="width: 60px;">

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -311,6 +311,7 @@ export class SheetsComponent{
   donutSize:any = 50;
   outerRadius:any = 70;
   chartBorderWidth: number = 0;
+  barCornerRadius: number = 0;
   color1:any;
   color2:any;
 
@@ -2298,6 +2299,7 @@ sheetSave(isDashboardTransfer?: boolean){
     donutSize : this.donutSize,
     outerRadius : this.outerRadius,
     chartBorderWidth : Number(this.chartBorderWidth),
+    barCornerRadius : Number(this.barCornerRadius),
     isDistributed : this.isDistributed,
     kpiFontSize : this.kpiFontSize,
     minValueGuage : this.minValueGuage,
@@ -4374,6 +4376,7 @@ customizechangeChartPlugin() {
     this.donutSize = data.donutSize ?? 50;
     this.outerRadius = data.outerRadius ?? 70;
     this.chartBorderWidth = Number(data.chartBorderWidth ?? 0);
+    this.barCornerRadius = Number(data.barCornerRadius ?? 0);
     this.isDistributed = data.isDistributed ?? true;
     this.kpiFontSize = data.kpiFontSize ?? 3;
     this.minValueGuage = data.minValueGuage ?? 0;
@@ -4497,6 +4500,7 @@ customizechangeChartPlugin() {
     this.donutSize = 50;
     this.outerRadius = 70;
     this.chartBorderWidth = 0;
+    this.barCornerRadius = 0;
     this.isDistributed = true;
     this.kpiFontSize = '3';
     this.minValueGuage = 0;


### PR DESCRIPTION
## Summary
- add `barCornerRadius` property to sheet configuration and persist through save, restore, and reset logic
- expose bar corner radius control in sheet UI and forward to Apex and ECharts components

## Testing
- `npm install` *(fails: 403 Forbidden fetching @angular-devkit/build-angular)*
- `npm test -- --watch=false` *(fails: sh: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68afcd3a08fc83209af078f423bd8a5e