### PR TITLE
Remove chart border width and add Treemap support

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -51,7 +51,6 @@ export class InsightApexComponent {
   @Input() dataLabels: any;
   @Input() label : any;
   @Input() donutSize : any;
-  @Input() chartBorderWidth : any = 0;
   @Input() barCornerRadius = 0;
   @Input() isDistributed : any;
   @Input() minValueGuage : any;

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -35,7 +35,6 @@ export class InsightEchartComponent {
   @Input() dualAxisRowData:any;
   @Input() donutSize:any;
   @Input() outerRadius:any;
-  @Input() chartBorderWidth:any = 0;
   @Input() barCornerRadius = 0;
   @Input() radarRowData:any;
   @Input() displayUnits:any;

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2606,7 +2606,7 @@
                 [dataLabelsFontPosition]="dataLabelsFontPosition" [dataLabelsColor]="dataLabelsColor" [measureAlignment]="measureAlignment" 
                 [dimensionAlignment]="dimensionAlignment" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                 [donutDecimalPlaces]="donutDecimalPlaces" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"
-                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
+                [drillDownObject]="drillDownObject" [sortType]="sortType" [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [dataLabelsBarFontPosition]="dataLabelsBarFontPosition" [barCornerRadius]="barCornerRadius"
                 [dataLabelsLineFontPosition]="dataLabelsLineFontPosition" [selectedColorScheme]="selectedColorScheme"
                 (saveOrUpdateChart)="setChartOptions($event)" (setDrilldowns)="setDrilldowns($event)"  [isMeasureDistribution]="isMeasureDistribution" [measureColorRanges]="measureColorRanges">
                 </app-insight-apex>
@@ -2624,7 +2624,7 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [barCornerRadius]="barCornerRadius"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)"  [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
             </div>
@@ -2636,7 +2636,7 @@
                 [yGridSwitch]="yGridSwitch" [yLabelSwitch]="yLabelSwitch" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize" [ylabelFontWeight]="ylabelFontWeight"
                 [yGridColor]="yGridColor" [yGridSwitch]="yGridSwitch" [color]="color" [measureColor]="measureColor" [dimensionColor]="dimensionColor" [dataLabelsFontSize]="dataLabelsFontSize" 
                 [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsColor]="dataLabelsColor" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix" [sortType]="sortType"
-                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
+                [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [selectedColorScheme]="selectedColorScheme" [isDistributed]="isDistributed" [barCornerRadius]="barCornerRadius"
                 (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [isMeasureDistribution]="isMeasureDistribution"
                 [measureColorRanges]="measureColorRanges"></app-insight-echart>
             </div>
@@ -2710,7 +2710,7 @@
                     <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
-                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [chartBorderWidth]="chartBorderWidth" [barCornerRadius]="barCornerRadius"
+                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [barCornerRadius]="barCornerRadius"
                     (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [leftLegend]="leftLegend" [topLegend]="topLegend" [rightLegend]="rightLegend" [bottomLegend]="bottomLegend" [legendOrient]="legendOrient" [isMeasureDistribution]="isMeasureDistribution"
                     [measureColorRanges]="measureColorRanges"></app-insight-echart>
                 </div>
@@ -5185,10 +5185,7 @@
                                                         <label class="mb-0">Bar Corner Radius (px)</label>
                                                         <input type="number" [(ngModel)]="barCornerRadius" min="0" step="1" class="form-control" style="width: 60px;">
                                                     </div>
-                                                    <div *ngIf="bar || horizontalBar || treemap" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
-                                                        <label class="mb-0">Chart Border Width (px)</label>
-                                                        <input type="number" [(ngModel)]="chartBorderWidth" min="0" step="1" class="form-control" style="width: 60px;">
-                                                    </div>
+        
 
                                                     <div *ngIf="kpi" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <label class="mb-0" for="font-size" step="1" >Font Size</label>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -310,7 +310,6 @@ export class SheetsComponent{
   legendsAllignment : any = 'bottom'
   donutSize:any = 50;
   outerRadius:any = 70;
-  chartBorderWidth: number = 0;
   barCornerRadius: number = 0;
   color1:any;
   color2:any;
@@ -2298,7 +2297,6 @@ sheetSave(isDashboardTransfer?: boolean){
     label : this.label,
     donutSize : this.donutSize,
     outerRadius : this.outerRadius,
-    chartBorderWidth : Number(this.chartBorderWidth),
     barCornerRadius : Number(this.barCornerRadius),
     isDistributed : this.isDistributed,
     kpiFontSize : this.kpiFontSize,
@@ -4375,7 +4373,6 @@ customizechangeChartPlugin() {
     this.label = data.label ?? true;
     this.donutSize = data.donutSize ?? 50;
     this.outerRadius = data.outerRadius ?? 70;
-    this.chartBorderWidth = Number(data.chartBorderWidth ?? 0);
     this.barCornerRadius = Number(data.barCornerRadius ?? 0);
     this.isDistributed = data.isDistributed ?? true;
     this.kpiFontSize = data.kpiFontSize ?? 3;
@@ -4499,7 +4496,6 @@ customizechangeChartPlugin() {
     this.label = true;
     this.donutSize = 50;
     this.outerRadius = 70;
-    this.chartBorderWidth = 0;
     this.barCornerRadius = 0;
     this.isDistributed = true;
     this.kpiFontSize = '3';

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1224,8 +1224,8 @@
                             accept="image/*">
                   </div>
                 </div>
-                <div class="card-header d-flex justify-content-between p-1" [attr.style]="((item.data?.title || item['type'] === 'image') ? 'display: flex !important;' : 'display: none !important;')">
-                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29) &&
+                 <div class="card-header d-flex justify-content-between p-1" [attr.style]="((item.data?.title || item['type'] === 'image') ? 'display: flex !important;' : 'display: none !important;')">
+                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18) &&
                   item['drillDownHierarchy'] && item['drillDownHierarchy'].length > 0){
                   <!-- <div class="col-lg-3 col-md-3"> -->
                   <button class="btn btn-primary " style="margin-right: 10px;" (click)="goDrillDownBack(item)"><i
@@ -1389,14 +1389,22 @@
                 </div>
                 }
                 @if(item['isEChart'] && !(item['chartId']=== 29 || item['chartId']=== 25 || item['chartId']=== 1 ||
-                item['chartId']=== 9) ){
+                item['chartId']=== 9 || item['chartId']=== 18) ){
                 <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
                   [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
                   <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
                     (chartClick)="onEChartClick($event,item)" class="echart-charts"
                     [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
                 </div>
-            
+
+                } @else if(item['isEChart'] && item['chartId']=== 18){
+                <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
+                  [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
+                  <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
+                    (chartClick)="onEChartClick($event,item)" class="echart-charts"
+                    [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
+                </div>
+
                 } @else if(item['isEChart'] && item['chartId']=== 29){
                 <div class="card-body p-1"
                   [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'scroll-overflow': !isOverflowHidden }">
@@ -1513,6 +1521,12 @@
                       [legend]="item.chartOptions.legend!" [labels]="item.chartOptions.labels!"
                       [responsive]="item.chartOptions.responsive!" [colors]="item.chartOptions.colors!"
                       [dataLabels]="item.chartOptions.dataLabels!" (chartInit)="onChartInit($event, item)"></apx-chart>
+                  </div>
+                  <div *ngIf="item.chartOptions && item['chartId'] === 18">
+                    <apx-chart [series]="item.chartOptions.series!" [chart]="item.chartOptions.chart!"
+                      [plotOptions]="item.chartOptions.plotOptions!" [dataLabels]="item.chartOptions.dataLabels!"
+                      [legend]="item.chartOptions.legend!" [colors]="item.chartOptions.colors!"
+                      (chartInit)="onChartInit($event, item)"></apx-chart>
                   </div>
                   <div *ngIf="item.chartOptions && item['chartId'] === 7">
                     <apx-chart [series]="item.chartOptions.series!" [chart]="item.chartOptions.chart!"
@@ -1814,7 +1828,7 @@
                           ? 'center' 
                           : ''">
                 <div class="card-header d-flex justify-content-between p-1">
-                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29) &&
+                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18) &&
                   item['drillDownHierarchy'] && item['drillDownHierarchy'].length > 0){
                   <!-- <div class="col-lg-3 col-md-3"> -->
                   <button class="btn btn-primary " style="margin-right: 10px;" (click)="goDrillDownBack(item)"><i
@@ -1902,16 +1916,24 @@
                   }
                 </div>
                 }
-                @if(item['isEChart'] && !(item['chartId']=== 29 || item['chartId']=== 25 || item['chartId']=== 1 ||
-                item['chartId']=== 9) ){
-                <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
-                  [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
-                  <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
-                    (chartClick)="onEChartClick($event,item)" class="echart-charts"
-                    [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
-                </div>
-            
-                } @else if(item['isEChart'] && item['chartId']=== 29){
+                  @if(item['isEChart'] && !(item['chartId']=== 29 || item['chartId']=== 25 || item['chartId']=== 1 ||
+                  item['chartId']=== 9 || item['chartId']=== 18) ){
+                  <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
+                    [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
+                    <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
+                      (chartClick)="onEChartClick($event,item)" class="echart-charts"
+                      [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
+                  </div>
+
+                  } @else if(item['isEChart'] && item['chartId']=== 18){
+                  <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
+                    [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
+                    <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
+                      (chartClick)="onEChartClick($event,item)" class="echart-charts"
+                      [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
+                  </div>
+
+                  } @else if(item['isEChart'] && item['chartId']=== 29){
                 <div class="card-body p-1"
                   [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'scroll-overflow': !isOverflowHidden }">
                   @if(chartType == 'map') {
@@ -2027,6 +2049,12 @@
                       [legend]="item.chartOptions.legend!" [labels]="item.chartOptions.labels!"
                       [responsive]="item.chartOptions.responsive!" [colors]="item.chartOptions.colors!"
                       [dataLabels]="item.chartOptions.dataLabels!" (chartInit)="onChartInit($event, item)"></apx-chart>
+                  </div>
+                  <div *ngIf="item.chartOptions && item['chartId'] === 18">
+                    <apx-chart [series]="item.chartOptions.series!" [chart]="item.chartOptions.chart!"
+                      [plotOptions]="item.chartOptions.plotOptions!" [dataLabels]="item.chartOptions.dataLabels!"
+                      [legend]="item.chartOptions.legend!" [colors]="item.chartOptions.colors!"
+                      (chartInit)="onChartInit($event, item)"></apx-chart>
                   </div>
                   <div *ngIf="item.chartOptions && item['chartId'] === 7">
                     <apx-chart [series]="item.chartOptions.series!" [chart]="item.chartOptions.chart!"

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -1082,7 +1082,7 @@ export class SheetsdashboardComponent implements OnDestroy {
       sheet.chartOptions.chart.events = {
         markerClick: (event: any, chartContext: any, config: any) => {
           let selectedXValue;
-          if(sheet.chartId == 24 || sheet.chartId == 10 || sheet.chartId == 17 || sheet.chartId == 4){
+          if(sheet.chartId == 24 || sheet.chartId == 10 || sheet.chartId == 17 || sheet.chartId == 4 || sheet.chartId == 18){
             selectedXValue = sheet.chartOptions.labels[config.dataPointIndex];
           } else {
             selectedXValue = sheet.chartOptions.xaxis.categories[config.dataPointIndex];
@@ -1093,7 +1093,7 @@ export class SheetsdashboardComponent implements OnDestroy {
         },
         dataPointSelection: function (event: any, chartContext: any, config: any) {
           let selectedXValue;
-          if(sheet.chartId == 24 || sheet.chartId == 10 || sheet.chartId == 17 || sheet.chartId == 4){
+          if(sheet.chartId == 24 || sheet.chartId == 10 || sheet.chartId == 17 || sheet.chartId == 4 || sheet.chartId == 18){
             selectedXValue = sheet.chartOptions.labels[config.dataPointIndex];
           } else {
             selectedXValue = sheet.chartOptions.xaxis.categories[config.dataPointIndex];
@@ -1929,6 +1929,14 @@ export class SheetsdashboardComponent implements OnDestroy {
           }
           delete item1['originalData'];
         }
+        if(item1.chartId == '18' && item1['originalData']){//treemap
+          if(item1.isEChart){
+            item1.echartOptions = item1['originalData'].chartOptions;
+          } else {
+            item1.chartOptions = item1['originalData'].chartOptions;
+          }
+          delete item1['originalData'];
+        }
         if(item1.chartId == '13' && item1['originalData']){//line
           if(item1.isEChart){
             item1.echartOptions = item1['originalData'].chartOptions;
@@ -2374,7 +2382,7 @@ allowDrop(ev : any): void {
           element.chartOptions.chart.events = {
             markerClick: (event: any, chartContext: any, config: any) => {
               let selectedXValue;
-              if (element.chartId == 24 || element.chartId == 10 || element.chartId == 17 || element.chartId == 4) {
+              if (element.chartId == 24 || element.chartId == 10 || element.chartId == 17 || element.chartId == 4 || element.chartId == 18) {
                 selectedXValue = element.chartOptions.labels[config.dataPointIndex];
               } else {
                 selectedXValue = element.chartOptions.xaxis.categories[config.dataPointIndex];
@@ -2385,7 +2393,7 @@ allowDrop(ev : any): void {
             },
             dataPointSelection: function (event: any, chartContext: any, config: any) {
               let selectedXValue;
-              if (element.chartId == 24 || element.chartId == 10) {
+              if (element.chartId == 24 || element.chartId == 10 || element.chartId == 18) {
                 selectedXValue = element.chartOptions.labels[config.dataPointIndex];
               } else {
                 selectedXValue = element.chartOptions.xaxis.categories[config.dataPointIndex];
@@ -4172,7 +4180,7 @@ setDashboardSheetData(item:any , isFilter : boolean , onApplyFilterClick : boole
         if(switchDb){
           item1.databaseId = item.databaseId;
        }
-        if(item1.isEChart){ 
+        if(item1.isEChart){
           if(!item1.originalData && !isLiveReloadData && !switchDb){
             item1['originalData'] = _.cloneDeep({chartOptions: item1.echartOptions});
           }
@@ -4198,8 +4206,42 @@ setDashboardSheetData(item:any , isFilter : boolean , onApplyFilterClick : boole
         }
         item1.chartOptions.labels = this.filteredColumnData[0].values.map((category : any)  => category === null ? 'null' : category);
       item1.chartOptions.series = this.filteredRowData[0].data;
+        }
       }
-    }
+      if((item.chart_id == '18' || item.chartId == '18' && (isFilter || isDrillDown)) || (item1.chartId == '18' && isDrillThrough)){//treemap
+        if(switchDb){
+          item1.databaseId = item.databaseId;
+       }
+        if(item1.isEChart){
+          if(!item1.originalData && !isLiveReloadData && !switchDb){
+            item1['originalData'] = _.cloneDeep({chartOptions: item1.echartOptions});
+          }
+          if(onApplyFilterClick && ((item1.drillDownHierarchy && item1.drillDownHierarchy.length > 0) || item1.drillDownIndex)){
+            item1.drillDownIndex = 0;
+            item1.drillDownObject = [];
+          }
+          let combinedArray = this.filteredColumnData[0].values.map((value : any, index : number) => ({
+            name: value === null ? 'null' : value,
+            value: this.filteredRowData[0].data[index]
+          }));
+          item1.echartOptions.series[0].data = combinedArray;
+          item1.echartOptions = {
+            ...item1.echartOptions,
+          };
+        } else {
+          if(!item1.originalData && !isLiveReloadData && !switchDb){
+            item1['originalData'] = _.cloneDeep({chartOptions: item1.chartOptions});
+          }
+          if(onApplyFilterClick && ((item1.drillDownHierarchy && item1.drillDownHierarchy.length > 0) || item1.drillDownIndex)){
+            item1.drillDownIndex = 0;
+            item1.drillDownObject = [];
+          }
+          item1.chartOptions.series[0].data = this.filteredColumnData[0].values.map((value : any, index : number) => ({
+            x: value === null ? 'null' : value,
+            y: this.filteredRowData[0].data[index]
+          }));
+        }
+      }
       if((item.chart_id == '13'|| item.chartId == '13' && (isFilter || isDrillDown)) || (item1.chartId == '13' && isDrillThrough)){//line
         if(switchDb){
           item1.databaseId = item.databaseId;


### PR DESCRIPTION
## Summary
- drop chartBorderWidth inputs from sheet and insight components
- handle Treemap charts in dashboard with filter and drag-drop support
- render Treemap charts in dashboard HTML for both Apex and ECharts, and include them in drilldown handling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_b_68afdc767d588320bbf44082f835f0b3