### PR TITLE
feat: validate bar corner radius input

### DIFF
--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -5183,7 +5183,11 @@
                                                     
                                                     <div *ngIf="bar || horizontalBar || treemap" class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <label class="mb-0">Bar Corner Radius (px)</label>
-                                                        <input type="number" [(ngModel)]="barCornerRadius" min="0" step="1" class="form-control" style="width: 60px;">
+                                                        <input type="number"
+                                                               [(ngModel)]="barCornerRadius"
+                                                               min="0" max="100" step="1"
+                                                               (keydown)="validateBarCornerRadius($event)"
+                                                               class="form-control" style="width:60px;">
                                                     </div>
         
 

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -4568,6 +4568,15 @@ customizechangeChartPlugin() {
     // this.KPISuffix = ''
   }
 
+  validateBarCornerRadius(event: KeyboardEvent): void {
+    const invalidKeys = ['e', 'E', '+', '-'];
+    if (invalidKeys.includes(event.key)) event.preventDefault();
+    setTimeout(() => {
+      if (this.barCornerRadius < 0) this.barCornerRadius = 0;
+      if (this.barCornerRadius > 100) this.barCornerRadius = 100;
+    });
+  }
+
   sendPrompt() {
     if (this.userPrompt.trim()) {
       const obj = {


### PR DESCRIPTION
## Summary
- validate bar corner radius input range and characters
- clamp bar corner radius and prevent invalid keys via new method

## Testing
- `npm test -- --watch=false` *(fails: ng: not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68b09f6ec3308320935e43f260cde268