### PR TITLE
feat: add radial chart support

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.html
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.html
@@ -188,10 +188,22 @@
             [labels]="chartOptions.labels"
             [plotOptions] = "chartOptions.plotOptions"
             [dataLabels]="chartOptions.dataLabels"
-            [legend]="chartOptions.legend" 
+            [legend]="chartOptions.legend"
             [colors]="chartOptions.colors">
             </apx-chart>
         </div>
+    </div>
+} @else if(chartType === 'radial'){
+    <div id="radialchart">
+        <apx-chart #radialchart
+        [series]="chartOptions.series"
+        [chart]="chartOptions.chart"
+        [labels]="chartOptions.labels"
+        [plotOptions]="chartOptions.plotOptions"
+        [legend]="chartOptions.legend"
+        [colors]="chartOptions.colors"
+        [tooltip]="chartOptions.tooltip">
+        </apx-chart>
     </div>
 } @else if(chartType === 'heatmap'){
     <div id="chart">

--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -80,6 +80,9 @@ export class InsightApexComponent {
   @Input() measureColorRanges: any;
   @Input() isMeasureDistribution: any;
   @Input() valueToDivide : any;
+  @Input() maxValueRadial: any;
+  @Input() startAngle: any;
+  @Input() endAngle: any;
   @Output() setDrilldowns = new EventEmitter<object>();
   @Output() saveOrUpdateChart = new EventEmitter<object>();
   
@@ -99,11 +102,13 @@ export class InsightApexComponent {
   @ViewChild('guageChart') guageCharts!: ChartComponent;
   @ViewChild('heatmapchart') heatmapCharts!: ChartComponent;
   @ViewChild('treemapchart') treemapCharts!: ChartComponent;
+  @ViewChild('radialchart') radialCharts!: ChartComponent;
 
   series: any[] = [];
   chartOptions: any = {};
   formattedData : any[] = [];
   guageNumber : any;
+  radialRawValues: any[] = [];
 
   ngOnInit(){
     // this.generateChart();
@@ -184,7 +189,7 @@ export class InsightApexComponent {
     if(changes['yGridSwitch']){
       this.yGridShowOrHide();
     }
-    if(['donut','pie'].includes(this.chartType) && changes['legendSwitch']){
+    if(['donut','pie','radial'].includes(this.chartType) && changes['legendSwitch']){
       this.legendsShowOrHide();
     }
     if(['donut','pie','treemap'].includes(this.chartType) && changes['dataLabels']){
@@ -193,10 +198,10 @@ export class InsightApexComponent {
     if(this.chartType == 'donut' && changes['label']){
       this.labelsShowOrHide();
     }
-    if(['bar','funnel','horizontalBar'].includes(this.chartType) && changes['isDistributed']){
+    if(['bar','funnel','horizontalBar','radial'].includes(this.chartType) && changes['isDistributed']){
       this.colorDistribution();
     }
-    if(['donut','pie'].includes(this.chartType) && changes['legendsAllignment']){
+    if(['donut','pie','radial'].includes(this.chartType) && changes['legendsAllignment']){
       this.legendPositionChange();
     }
     if(this.chartType == 'donut' && changes['donutSize']){
@@ -210,6 +215,12 @@ export class InsightApexComponent {
     }
     if(changes['gridColor']){
       this.gridLineColor();
+    }
+    if(this.chartType === 'radial' && (changes['startAngle'] || changes['endAngle'])){
+      this.updateRadialAngles();
+    }
+    if(this.chartType === 'radial' && changes['maxValueRadial']){
+      this.updateSeries();
     }
     if((changes['displayUnits'] || changes['decimalPlaces'] || changes['prefix'] || changes['suffix'] || changes['donutDecimalPlaces']) && !changes['chartType']){
       this.updateNumberFormat();
@@ -301,10 +312,20 @@ export class InsightApexComponent {
     } else if (this.chartType === 'donut') {
       this.chartOptions.series = this.chartsRowData;
       this.donutCharts?.updateOptions({ series: this.chartOptions.series });
+    } else if (this.chartType === 'radial') {
+      const max = this.maxValueRadial || Math.max(...this.chartsRowData);
+      this.radialRawValues = [...this.chartsRowData];
+      this.chartOptions.series = this.chartsRowData.map((v: any) => max ? (v / max) * 100 : 0);
+      this.chartOptions.tooltip = {
+        y: {
+          formatter: (_: any, opts: any) => this.radialRawValues[opts.seriesIndex]
+        }
+      };
+      this.radialCharts?.updateOptions({ series: this.chartOptions.series, tooltip: this.chartOptions.tooltip });
     } else if (this.chartType === 'funnel') {
       this.chartOptions.series = this.dualAxisRowData;
       this.funnelCharts?.updateOptions({ series: this.chartOptions.series });
-    } 
+    }
     else if (this.chartType === 'heatmap') {
       this.chartOptions.series = this.dualAxisRowData;
       this.heatmapCharts?.updateOptions({ series: this.chartOptions.series });
@@ -351,6 +372,9 @@ export class InsightApexComponent {
     } else if(this.donutCharts){
       this.chartOptions.labels = this.chartsColumnData.map((category : any)  => category === null ? 'null' : category);
       this.donutCharts.updateOptions({ labels: this.chartOptions.labels });
+    } else if(this.radialCharts){
+      this.chartOptions.labels = this.chartsColumnData.map((category: any) => category === null ? 'null' : category);
+      this.radialCharts.updateOptions({ labels: this.chartOptions.labels });
     } else if(this.funnelCharts){
       this.chartOptions.xaxis.categories = categories;
       this.funnelCharts.updateOptions({ xaxis: this.chartOptions.xaxis });
@@ -393,6 +417,8 @@ export class InsightApexComponent {
       this.funnelCharts.destroy();
     } else if(this.guageCharts){
       this.guageCharts.destroy();
+    } else if(this.radialCharts){
+      this.radialCharts.destroy();
     } else if(this.heatmapCharts){
       this.heatmapCharts.destroy();
     }
@@ -423,6 +449,8 @@ export class InsightApexComponent {
       this.multiLineChart();
     } else if(this.chartType === 'donut'){
       this.donutChart();
+    } else if(this.chartType === 'radial'){
+      this.radialChart();
     } else if(this.chartType === 'heatmap'){
       this.heatMapChart();
     } else if(this.chartType === 'funnel'){
@@ -446,7 +474,7 @@ export class InsightApexComponent {
     });
   }
   validateSeriesData(series: any[]): boolean {
-    if(['pie', 'donut', 'guage'].includes(this.chartType)) {
+    if(['pie', 'donut', 'guage', 'radial'].includes(this.chartType)) {
       return series?.every((value: any) => typeof value === 'number' || (!isNaN(value) && !isNaN(parseFloat(value))) || value === null);
     } else if(['treemap'].includes(this.chartType)){
       return series?.every((set) =>
@@ -1820,6 +1848,35 @@ xaxis: {
       },
     };
   }
+  radialChart(){
+    const max = this.maxValueRadial || Math.max(...this.chartsRowData);
+    this.radialRawValues = [...this.chartsRowData];
+    const series = this.chartsRowData.map((v: any) => max ? (v / max) * 100 : 0);
+    this.chartOptions = {
+      series: series,
+      chart: {
+        type: 'radialBar',
+        background: this.backgroundColor,
+      },
+      plotOptions: {
+        radialBar: {
+          startAngle: this.startAngle,
+          endAngle: this.endAngle,
+        }
+      },
+      labels: this.chartsColumnData.map((category: any) => category === null ? 'null' : category),
+      legend: {
+        show: this.legendSwitch,
+        position: this.legendsAllignment
+      },
+      colors: this.isDistributed ? this.selectedColorScheme : [this.color],
+      tooltip: {
+        y: {
+          formatter: (_: any, opts: any) => this.radialRawValues[opts.seriesIndex]
+        }
+      }
+    };
+  }
   heatMapChart(){
     const dimensions: Dimension[] = this.dualAxisColumnData;
     const categories = this.flattenDimensions(dimensions);
@@ -2975,6 +3032,9 @@ xaxis: {
     else if (this.donutCharts) {
       this.donutCharts.updateOptions(object);
     }
+    else if (this.radialCharts) {
+      this.radialCharts.updateOptions(object);
+    }
     else if (this.treemapCharts) {
       this.treemapCharts.updateOptions(object);
     }
@@ -3019,6 +3079,18 @@ xaxis: {
       this.chartOptions.plotOptions.treemap.distributed = this.isDistributed;
       let object = { colors: this.chartOptions.colors, plotOptions: this.chartOptions.plotOptions };
       this.treemapCharts?.updateOptions(object);
+    } else if(this.chartType === 'radial'){
+      this.chartOptions.colors = this.isDistributed ? this.selectedColorScheme : [this.color];
+      let object = { colors: this.chartOptions.colors };
+      this.radialCharts?.updateOptions(object);
+    }
+  }
+  updateRadialAngles(){
+    if(this.chartOptions?.plotOptions?.radialBar){
+      this.chartOptions.plotOptions.radialBar.startAngle = this.startAngle;
+      this.chartOptions.plotOptions.radialBar.endAngle = this.endAngle;
+      const object = { plotOptions: this.chartOptions.plotOptions };
+      this.radialCharts?.updateOptions(object);
     }
   }
   legendPositionChange(){
@@ -3086,6 +3158,9 @@ xaxis: {
     else if (this.donutCharts) {
       this.donutCharts.updateOptions(object);
     }
+    else if (this.radialCharts) {
+      this.radialCharts.updateOptions(object);
+    }
     else if (this.guageCharts) {
       this.guageCharts.updateOptions(object);
     }
@@ -3104,7 +3179,7 @@ xaxis: {
       }
       object = { series: this.chartOptions.series };
     }
-    else if(['bar','funnel','horizontalBar','treemap'].includes(this.chartType)){
+    else if(['bar','funnel','horizontalBar','treemap','radial'].includes(this.chartType)){
       if(this.chartOptions?.colors){
         this.chartOptions.colors = this.isDistributed ? this.selectedColorScheme : [this.color];
       }
@@ -3174,6 +3249,9 @@ xaxis: {
     }
     else if(this.chartType === 'treemap'){
       this.treemapCharts?.updateOptions(object);
+    }
+    else if(this.chartType === 'radial'){
+      this.radialCharts?.updateOptions(object);
     }
   }
   gridLineColor(){

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2601,7 +2601,7 @@
                 [ylabelFontWeight]="ylabelFontWeight" [isBold]="isBold" [yLabelFontFamily]="yLabelFontFamily" [yLabelFontSize]="yLabelFontSize"
                 [barColor]="barColor" [lineColor]="lineColor" [gridColor]="GridColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"
                 [label]="label" [donutSize]="donutSize" [isDistributed]="isDistributed" [minValueGuage]="minValueGuage" [maxValueGuage]="maxValueGuage"
-                [gaugeDisplayMode]="gaugeDisplayMode" [valueToDivide]="valueToDivide"
+                [gaugeDisplayMode]="gaugeDisplayMode" [valueToDivide]="valueToDivide" [startAngle]="radialStartAngle" [endAngle]="radialEndAngle" [maxValueRadial]="maxValueRadial"
                 [legendsAllignment]="legendsAllignment" [dataLabelsFontFamily]="dataLabelsFontFamily" [dataLabelsFontSize]="dataLabelsFontSize"
                 [dataLabelsFontPosition]="dataLabelsFontPosition" [dataLabelsColor]="dataLabelsColor" [measureAlignment]="measureAlignment" 
                 [dimensionAlignment]="dimensionAlignment" [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
@@ -3904,7 +3904,7 @@
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                           <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                             <button
                                                               ngbAccordionButton
@@ -4045,7 +4045,7 @@
                                                           </div>
                                                     </div>
 
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || funnel || kpi || guage || calendar || radar || treemap || pivotTable)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || funnel || kpi || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                             <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                               <button
                                                                 ngbAccordionButton
@@ -4188,7 +4188,7 @@
                                                             </div>
                                                     </div>
 
-                                                    <div *ngIf="!((pie && chartId) || donut || calendar || map || pivotTable || (table && draggedRows?.length === 0))" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((pie && chartId) || donut || calendar || map || pivotTable || radial || (table && draggedRows?.length === 0))" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -4585,7 +4585,7 @@
                                                         </div>
                                                     </div>
                                                   
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -4641,7 +4641,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -5050,7 +5050,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div *ngIf="(draggedColumns?.length !== 0 || draggedRows?.length !==0) && !(kpi || guage || calendar ||pivotTable || treemap || (!isApexCharts && funnel))" [class.disabled]="!isTopFilter" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="(draggedColumns?.length !== 0 || draggedRows?.length !==0) && !(kpi || guage || calendar || pivotTable || treemap || radial || (!isApexCharts && funnel))" [class.disabled]="!isTopFilter" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -5356,7 +5356,19 @@
                                                             <option value="value">Value</option>
                                                             <option value="both">Both</option>
                                                             </select>
-                                                        
+
+                                                    </div>
+                                                    <div *ngIf="radial" class="d-flex align-items-center justify-content-between mb-0 flex-wrap gap-2 p-2">
+                                                        <div>
+                                                            <label for="radialStartAngle">Start Angle:</label>
+                                                            <input type="number" class="form-control fs-14" [(ngModel)]="radialStartAngle" id="radialStartAngle"/>
+
+                                                            <label for="radialEndAngle">End Angle:</label>
+                                                            <input type="number" class="form-control fs-14" [(ngModel)]="radialEndAngle" id="radialEndAngle"/>
+
+                                                            <label for="maxValueRadial">Max Value:</label>
+                                                            <input type="number" class="form-control fs-14" [(ngModel)]="maxValueRadial" id="maxValueRadial"/>
+                                                        </div>
                                                     </div>
                                                     <!-- <div *ngIf="bar || funnel && isApexCharts" class="d-flex align-items-center justify-content-between mb-0 flex-wrap gap-2 p-3">
                                                         <label for="sorting">Sort by: </label>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -297,6 +297,9 @@ export class SheetsComponent{
   guageNumber:any;
   eFunnelChartOptions: any;
   valueToDivide:any;
+  radialStartAngle: number = 0;
+  radialEndAngle: number = 360;
+  maxValueRadial: number = 100;
 
   barColor : any = '#4382f7';
   lineColor : any = '#38ff98';
@@ -1616,6 +1619,7 @@ try {
   grouped = false;
   multiLine = false;
   donut = false;
+  radial = false;
   kpi = false;
   heatMap = false;
   funnel = false;
@@ -1644,6 +1648,7 @@ try {
     this.heatMap = heatMap;
     this.funnel = funnel;
     this.guage = guage;
+    this.radial = (chartId === 20);
     this.treemap = (chartId === 18);
     this.map = map;
     this.calendar = calendar;
@@ -2303,6 +2308,9 @@ sheetSave(isDashboardTransfer?: boolean){
     minValueGuage : this.minValueGuage,
     gaugeDisplayMode: this.gaugeDisplayMode,
     maxValueGuage : this.maxValueGuage,
+    startAngle: this.radialStartAngle,
+    endAngle: this.radialEndAngle,
+    maxValueRadial: this.maxValueRadial,
     donutDecimalPlaces : this.donutDecimalPlaces,
     decimalPlaces : this.decimalPlaces,
     legendsAllignment : this.legendsAllignment,
@@ -4262,6 +4270,10 @@ routeConfigure(){
     // Heat Map
     this.chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,false,false,false,26);
 
+  } else if (chartType.includes("radial")) {
+    // Radial
+    this.chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,false,20);
+
   } else if (chartType.includes("funnel")) {
     // Funnel
     this.chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,true,false,false,false,false,false,27);
@@ -4379,6 +4391,9 @@ customizechangeChartPlugin() {
     this.minValueGuage = data.minValueGuage ?? 0;
     this.gaugeDisplayMode = data.gaugeDisplayMode ?? 'both';
     this.maxValueGuage = data.maxValueGuage ?? 100;
+    this.radialStartAngle = data.startAngle ?? 0;
+    this.radialEndAngle = data.endAngle ?? 360;
+    this.maxValueRadial = data.maxValueRadial ?? 100;
     this.donutDecimalPlaces = data.donutDecimalPlaces ?? 2;
     this.decimalPlaces = data.decimalPlaces ?? 2;
     this.legendsAllignment = data.legendsAllignment ?? 'bottom';
@@ -4505,6 +4520,9 @@ customizechangeChartPlugin() {
     this.donutDecimalPlaces = 2;
     // this.decimalPlaces = 0;
     this.legendsAllignment = 'bottom';
+    this.radialStartAngle = 0;
+    this.radialEndAngle = 360;
+    this.maxValueRadial = 100;
     // this.displayUnits = 'none';
     // this.suffix = '';
     // this.prefix = '';

--- a/src/app/services/chart-render.service.ts
+++ b/src/app/services/chart-render.service.ts
@@ -22,6 +22,7 @@ export interface ChartFlags {
   calendar: boolean;
   pivotTable: boolean;
   treemap: boolean;
+  radial: boolean;
 }
 
 export interface ChartConfig {
@@ -53,6 +54,7 @@ export class ChartRenderService {
     calendar: false,
     pivotTable: false,
     treemap: false,
+    radial: false,
   };
 
   private chartConfigMap: Record<number, ChartConfig> = {
@@ -74,6 +76,7 @@ export class ChartRenderService {
     29: { chartType: 'map', flags: { ...this.baseFlags, map: true } },
     11: { chartType: 'calendar', flags: { ...this.baseFlags, calendar: true } },
     18: { chartType: 'treemap', flags: { ...this.baseFlags, treemap: true } },
+    20: { chartType: 'radial', flags: { ...this.baseFlags, radial: true } },
   };
 
   getChartConfig(chartId: number): ChartConfig | undefined {


### PR DESCRIPTION
## Summary
- add ApexCharts radial chart with percentage-based fill and raw-value tooltip
- expose radial chart options like max value and angles through Sheets
- register radial chart type in chart rendering service
- hide non-radial customizations and add start/end angle and max value inputs

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b096f31d40832085aa5a213b4f3c82