### PR TITLE
Expose radial chart legend controls

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -321,7 +321,19 @@ export class InsightApexComponent {
           formatter: (_: any, opts: any) => this.radialRawValues[opts.seriesIndex]
         }
       };
-      this.radialCharts?.updateOptions({ series: this.chartOptions.series, tooltip: this.chartOptions.tooltip });
+      if (!this.chartOptions.plotOptions) {
+        this.chartOptions.plotOptions = { radialBar: {} } as any;
+      }
+      if (!this.chartOptions.plotOptions.radialBar) {
+        this.chartOptions.plotOptions.radialBar = {} as any;
+      }
+      this.chartOptions.plotOptions.radialBar.dataLabels = {
+        ...(this.chartOptions.plotOptions.radialBar.dataLabels || {}),
+        value: {
+          formatter: (val: number) => `${val.toFixed(2)}%`
+        }
+      };
+      this.radialCharts?.updateOptions({ series: this.chartOptions.series, tooltip: this.chartOptions.tooltip, plotOptions: this.chartOptions.plotOptions });
     } else if (this.chartType === 'funnel') {
       this.chartOptions.series = this.dualAxisRowData;
       this.funnelCharts?.updateOptions({ series: this.chartOptions.series });
@@ -1862,6 +1874,11 @@ xaxis: {
         radialBar: {
           startAngle: this.startAngle,
           endAngle: this.endAngle,
+          dataLabels: {
+            value: {
+              formatter: (val: number) => `${val.toFixed(2)}%`
+            }
+          }
         }
       },
       labels: this.chartsColumnData.map((category: any) => category === null ? 'null' : category),
@@ -3103,6 +3120,9 @@ xaxis: {
     }
     else if (this.donutCharts) {
       this.donutCharts.updateOptions(object);
+    }
+    else if (this.radialCharts) {
+      this.radialCharts.updateOptions(object);
     }
     else if (this.treemapCharts) {
       this.treemapCharts.updateOptions(object);

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -5117,7 +5117,7 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                                    <div *ngIf="((pie && chartId) || donut || radar)">
+                                                    <div *ngIf="((pie && chartId) || donut || radar || radial)">
                                                         <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                             <div class=""> 
                                                                 <label class="mb-0">Legends </label>


### PR DESCRIPTION
## Summary
- show legend toggle and alignment options for radial charts
- update legend position handling to support radial charts
- format radial chart labels as percentages while tooltips show raw values

## Testing
- `npm test` *(fails: sh: 1: ng: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@angular-devkit%2fbuild-angular)*

------
https://chatgpt.com/codex/tasks/task_b_68b13635a8d08320b0a9a8dd72031841