### PR TITLE
fix: apply bar corner radius to all sides

### DIFF
--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -292,7 +292,12 @@ export class InsightEchartComponent {
       series: [
         {
           itemStyle: {
-            borderRadius: [this.barCornerRadius, this.barCornerRadius, 0, 0]
+            borderRadius: [
+              this.barCornerRadius,
+              this.barCornerRadius,
+              this.barCornerRadius,
+              this.barCornerRadius
+            ]
           },
           label: { show: true,
             position: this.dataLabelsFontPosition,
@@ -422,7 +427,12 @@ horizontalBarChart(chartsColumnData?: any, chartsRowData?: any) {
         type: 'bar',
         data: this.chartsRowData,
         itemStyle: {
-          borderRadius: [0, this.barCornerRadius, this.barCornerRadius, 0]
+          borderRadius: [
+            this.barCornerRadius,
+            this.barCornerRadius,
+            this.barCornerRadius,
+            this.barCornerRadius
+          ]
         },
         label: {
           show: true,
@@ -2045,7 +2055,12 @@ let barChartOptions = {
   series: [
     {
       itemStyle: {
-        borderRadius: [this.barCornerRadius, this.barCornerRadius, 0, 0]
+        borderRadius: [
+          this.barCornerRadius,
+          this.barCornerRadius,
+          this.barCornerRadius,
+          this.barCornerRadius
+        ]
       },
       label: { show: true,
         position: this.dataLabelsFontPosition,
@@ -2435,9 +2450,7 @@ chartInitialize(){
         this.chartOptions.series.forEach((s: any) => {
           s.itemStyle = {
             ...(s.itemStyle || {}),
-            borderRadius: this.chartType === 'bar'
-              ? [radius, radius, 0, 0]
-              : [0, radius, radius, 0]
+            borderRadius: [radius, radius, radius, radius]
           };
         });
       }


### PR DESCRIPTION
## Summary
- ensure bar charts use the same corner radius on all four sides
- update bar corner radius change detection to apply full array

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b3de7da2c48320ae677ca70d5ca9e9