### PR TITLE
feat: support radial and treemap chart options

### DIFF
--- a/src/app/services/dashboard-transfer.service.spec.ts
+++ b/src/app/services/dashboard-transfer.service.spec.ts
@@ -1,16 +1,61 @@
-import { TestBed } from '@angular/core/testing';
-
 import { DashboardTransferService } from './dashboard-transfer.service';
 
 describe('DashboardTransferService', () => {
   let service: DashboardTransferService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(DashboardTransferService);
+    service = new DashboardTransferService({} as any, {} as any);
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('updateChartOptions', () => {
+    it('should update Apex treemap options', () => {
+      const chartOptions: any = { series: [{ data: [] }] };
+      const result = service.updateChartOptions(
+        chartOptions,
+        18,
+        true,
+        ['A', 'B'],
+        [{ name: 'val', data: [10, 20] }]
+      );
+      expect(result.series[0].data).toEqual([
+        { x: 'A', y: 10 },
+        { x: 'B', y: 20 }
+      ]);
+    });
+
+    it('should update Apex radial options', () => {
+      const chartOptions: any = {};
+      const result = service.updateChartOptions(
+        chartOptions,
+        20,
+        true,
+        ['A', 'B'],
+        [{ name: 'val', data: [20, 40] }]
+      );
+      expect(result.series).toEqual([50, 100]);
+      expect(result.labels).toEqual(['A', 'B']);
+      expect(result.plotOptions.radialBar.max).toBe(40);
+      const tooltipValue = result.tooltip.y.formatter(null, { seriesIndex: 1 });
+      expect(tooltipValue).toBe(40);
+    });
+
+    it('should update ECharts treemap options', () => {
+      const chartOptions: any = { series: [{ data: [] }] };
+      const result = service.updateChartOptions(
+        chartOptions,
+        18,
+        false,
+        ['A', 'B'],
+        [{ name: 'val', data: [10, 20] }]
+      );
+      expect(result.series[0].data).toEqual([
+        { name: 'A', value: 10 },
+        { name: 'B', value: 20 }
+      ]);
+    });
   });
 });

--- a/src/app/services/dashboard-transfer.service.ts
+++ b/src/app/services/dashboard-transfer.service.ts
@@ -217,9 +217,34 @@ export class DashboardTransferService {
     if ([24, 10].includes(chartId)) {
       chartOptions.series = multiSeriesChartData[0]?.data || [];
       chartOptions.labels = xAxisCategories;
-    } else if(chartId == 28){
+    } else if (chartId == 28) {
       chartOptions.series = multiSeriesChartData[0]?.data || [];
       chartOptions.labels = [multiSeriesChartData[0]?.name];
+    } else if (chartId == 20) {
+      const rawValues = multiSeriesChartData[0]?.data || [];
+      const maxVal = chartOptions?.plotOptions?.radialBar?.max || Math.max(...rawValues, 0);
+      chartOptions.series = rawValues.map((val: number) => maxVal ? (val / maxVal) * 100 : 0);
+      chartOptions.labels = xAxisCategories;
+      chartOptions.plotOptions = chartOptions.plotOptions || {};
+      chartOptions.plotOptions.radialBar = chartOptions.plotOptions.radialBar || {};
+      chartOptions.plotOptions.radialBar.max = maxVal;
+      const radialRaw = rawValues;
+      chartOptions.tooltip = {
+        ...(chartOptions.tooltip || {}),
+        y: {
+          formatter: (_: any, opts: any) => radialRaw[opts.seriesIndex]
+        }
+      };
+    } else if (chartId == 18) {
+      const data = xAxisCategories.map((name, index) => ({
+        x: name,
+        y: multiSeriesChartData[0]?.data[index]
+      }));
+      if (chartOptions.series && chartOptions.series[0]) {
+        chartOptions.series[0].data = data;
+      } else {
+        chartOptions.series = [{ data }];
+      }
     } else {
       chartOptions.series?.forEach((row: any, index: number) => {
         row.data = multiSeriesChartData[index]?.data || [];
@@ -228,7 +253,7 @@ export class DashboardTransferService {
       chartOptions.xaxis.categories = xAxisCategories;
     }
   } else {
-    if (![12, 26, 11, 29, 24, 10, 27].includes(chartId)) {
+    if (![12, 26, 11, 29, 24, 10, 27, 18].includes(chartId)) {
       chartOptions.series?.forEach((row: any, index: number) => {
         row.data = multiSeriesChartData[index]?.data || [];
       });
@@ -245,6 +270,14 @@ export class DashboardTransferService {
       chartOptions.series.forEach((row: any, index: any) => {
         row.data = heatmapData;
       });
+    } else if (chartId == 18) {
+      const data: any[] = [];
+      xAxisCategories.forEach((col: any, index: any) => {
+        data.push({ name: col, value: multiSeriesChartData[0].data[index] });
+      });
+      if (chartOptions.series && chartOptions.series[0]) {
+        chartOptions.series[0].data = data;
+      }
     }
 
     if (chartId == 4) {
@@ -375,6 +408,8 @@ export class DashboardTransferService {
         data.push({ value: multiSeriesChartData[0].data[index], name: col })
       });
       chartOptions.series[0].data = data;
+    } else if (chartId == 18) {
+      // Treemap does not use xAxis configuration
     } else {
       chartOptions.xAxis = {
         ...(chartOptions.xAxis || {}),


### PR DESCRIPTION
## Summary
- extend dashboard transfer to update Apex radial chart options and treemap options
- handle treemap data mapping for ECharts
- add unit tests for radial and treemap chart handling

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden accessing packages)*

------
https://chatgpt.com/codex/tasks/task_b_68b3e9fa7a0c832083e65809c78dcd56