### PR TITLE
Remove treemap zoom dependency

### DIFF
--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -1729,9 +1729,8 @@ treemapChart(chartsColumnData?: any, chartsRowData?: any){
     },
     series: [{
       type: 'treemap',
-      roam :  this.isZoom,
       breadcrumb: {
-        show: false 
+        show: false
       },
       itemStyle: {
         borderRadius: this.barCornerRadius
@@ -2231,18 +2230,7 @@ chartInitialize(){
       if (this.chartInstance) {
 
         let obj ={};
-        if (this.chartType === 'treemap') {
-          obj = {
-            series: [{
-              type: 'treemap',
-              roam: this.isZoom ? true : false,
-              nodeClick: this.isZoom ? 'zoomToNode' : false,
-              breadcrumb: {
-                show: this.isZoom
-              }
-            }]
-          };
-        } else if (this.chartType === 'horizontalBar') {
+        if (this.chartType === 'horizontalBar') {
           obj = {
             dataZoom: this.isZoom ? [
               {

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2707,7 +2707,7 @@
             }
             @else if(treemap && chartId){
                 <div class="card-body">
-                    <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                    <app-insight-echart [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
                     [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
                     [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
                     [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject" [barCornerRadius]="barCornerRadius"
@@ -4576,7 +4576,7 @@
                                                         </div>
                                                     </div>
                                                     
-                                                    <div *ngIf="!isApexCharts && isEChatrts && !(pie || donut || funnel || calendar || radar || kpi || table || pivotTable)" class="d-flex align-items-center justify-content-between  mb-2 flex-wrap gap-2 p-2 border rounded-2">
+                                                    <div *ngIf="!isApexCharts && isEChatrts && !(pie || donut || funnel || calendar || radar || kpi || table || pivotTable || treemap)" class="d-flex align-items-center justify-content-between  mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <div class=""> 
                                                             <label class="mb-0">Zoom </label>
                                                         </div>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -2281,7 +2281,7 @@ sheetSave(isDashboardTransfer?: boolean){
   this.validateRadialAngles();
   savedChartOptions = this.chartOptionsSet;
   let customizeObject = {
-    isZoom : this.isZoom,
+    ...(this.treemap ? {} : { isZoom: this.isZoom }),
     xGridColor : this.xGridColor,
     xGridSwitch : this.xGridSwitch,
     xLabelSwitch : this.xLabelSwitch,
@@ -4434,7 +4434,9 @@ customizechangeChartPlugin() {
   }
 
   setCustomizeOptions(data: any) {
-    this.isZoom = data.isZoom ?? true;
+    if (!this.treemap) {
+      this.isZoom = data.isZoom ?? true;
+    }
     this.xGridColor = data.xGridColor ?? '#2392c1';
     this.xGridSwitch = data.xGridSwitch ?? false;
     this.xLabelSwitch = data.xLabelSwitch ?? true;


### PR DESCRIPTION
## Summary
- Keep zoom options for non-treemap charts and exclude treemap from zoom bindings
- Save and restore zoom state only for charts that support it
- Simplify ECharts treemap config so it no longer enables roaming or responds to zoom

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b52a9ed3dc832082f1eaa33a79d881