### PR TITLE
Show raw radial chart values in legends

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -320,7 +320,10 @@ export class InsightApexComponent {
           formatter: (_: any, opts: any) => this.radialRawValues[opts.seriesIndex]
         }
       };
-      this.radialCharts?.updateOptions({ series: this.chartOptions.series, tooltip: this.chartOptions.tooltip, plotOptions: this.chartOptions.plotOptions });
+      this.chartOptions.legend = this.chartOptions.legend || {};
+      this.chartOptions.legend.formatter = (seriesName: string, opts: any) =>
+        `${seriesName}: ${this.formatNumber(this.radialRawValues[opts.seriesIndex])}`;
+      this.radialCharts?.updateOptions({ series: this.chartOptions.series, tooltip: this.chartOptions.tooltip, plotOptions: this.chartOptions.plotOptions, legend: this.chartOptions.legend });
     } else if (this.chartType === 'funnel') {
       this.chartOptions.series = this.dualAxisRowData;
       this.funnelCharts?.updateOptions({ series: this.chartOptions.series });
@@ -1873,6 +1876,8 @@ xaxis: {
       fontSize: "12px",
       offsetX: 10,
       offsetY: 10,
+      formatter: (seriesName: string, opts: any) =>
+        `${seriesName}: ${this.formatNumber(this.radialRawValues[opts.seriesIndex])}`
       },
       colors: this.isDistributed ? this.selectedColorScheme : [this.color],
     };

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -1178,6 +1178,23 @@ export class SheetsdashboardComponent implements OnDestroy {
           }
         }
       };
+      if (sheet.chartId === 20) {
+        const maxVal = sheet.chartOptions?.plotOptions?.radialBar?.max;
+        const rawValues = (sheet.chartOptions.series || []).map((p: number) =>
+          maxVal ? (p * maxVal) / 100 : 0
+        );
+        sheet.chartOptions.legend = {
+          ...(sheet.chartOptions.legend || {}),
+          formatter: (seriesName: string, opts: any) =>
+            `${seriesName}: ${this.formatNumber(
+              rawValues[opts.seriesIndex],
+              sheet.numberFormat?.decimalPlaces ?? 0,
+              sheet.numberFormat?.displayUnits ?? 'none',
+              sheet.numberFormat?.prefix ?? '',
+              sheet.numberFormat?.suffix ?? ''
+            )}`
+        };
+      }
       } else if (sheet.chartId == 29) {
         this.chartType = 'map';
         sheet.echartOptions?.series[0]?.data?.forEach((data: any) => {
@@ -4293,6 +4310,17 @@ setDashboardSheetData(item:any , isFilter : boolean , onApplyFilterClick : boole
         const maxVal = item1.chartOptions?.plotOptions?.radialBar?.max;
         const normalizedValues = values.map((v: any) => maxVal ? (v / maxVal) * 100 : 0);
         item1.chartOptions.series = normalizedValues;
+        item1.chartOptions.legend = {
+          ...(item1.chartOptions.legend || {}),
+          formatter: (seriesName: string, opts: any) =>
+            `${seriesName}: ${this.formatNumber(
+              values[opts.seriesIndex],
+              item1.numberFormat?.decimalPlaces ?? 0,
+              item1.numberFormat?.displayUnits ?? 'none',
+              item1.numberFormat?.prefix ?? '',
+              item1.numberFormat?.suffix ?? ''
+            )}`
+        };
       }
       if((item.chart_id == '18' || item.chartId == '18' && (isFilter || isDrillDown)) || (item1.chartId == '18' && isDrillThrough)){//treemap
         if(switchDb){
@@ -6483,10 +6511,17 @@ formatNumber(value: number,decimalPlaces:number,displayUnits:string,prefix:strin
               return `${category}: ${formattedValue}`;
             }
           }
+        } else if(chartId === 20){
+          if (sheet.chartOptions?.legend) {
+            const maxVal = sheet.chartOptions?.plotOptions?.radialBar?.max;
+            const rawValues = (sheet.chartOptions.series || []).map((p: number) => maxVal ? (p * maxVal) / 100 : 0);
+            sheet.chartOptions.legend.formatter = (seriesName: string, opts: any) =>
+              `${seriesName}: ${this.formatNumber(rawValues[opts.seriesIndex], numberFormat?.decimalPlaces, numberFormat?.displayUnits, numberFormat?.prefix, numberFormat?.suffix)}`;
+          }
         } else if(chartId === 28){
           if (sheet.chartOptions?.plotOptions?.radialBar?.dataLabels?.value) {
             sheet.chartOptions.plotOptions.radialBar.dataLabels.value.formatter = (val: any, opts: any) => {
-              
+
                 switch (sheet.customizeOptions.gaugeDisplayMode) {
                   case 'percentage':
                     return `${val.toFixed(2)}%`;


### PR DESCRIPTION
## Summary
- add legend formatter to display raw values for radial charts
- propagate raw radial values through dashboard updates and number formatting

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b540ccedf083208e05541bc30d42aa