### PR TITLE
feat: add treemap drilldown

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -1981,6 +1981,25 @@ xaxis: {
         height: 350,
         type: 'treemap',
         background: this.backgroundColor,
+        events: {
+          dataPointSelection: function (event: any, chartContext: any, config: any) {
+            const selectedXValue = self.chartsColumnData[config.dataPointIndex];
+            if (self.drillDownIndex < self.draggedDrillDownColumns.length - 1) {
+              let nestedKey = self.draggedDrillDownColumns[self.drillDownIndex];
+              nestedKey = nestedKey === 'date' ? 'year/month/day' :  (nestedKey === 'time' ? 'date' : nestedKey);
+              self.drillDownIndex++;
+              let obj = { [nestedKey]: selectedXValue };
+              self.drillDownObject.push(obj);
+              let dObject = {
+                drillDownIndex : self.drillDownIndex,
+                draggedDrillDownColumns :self.draggedDrillDownColumns,
+                drillDownObject : self.drillDownObject,
+                chartOptions : JSON.parse(JSON.stringify(self.chartOptions))
+              };
+              self.setDrilldowns.emit(dObject);
+            }
+          }
+        }
       },
       plotOptions: {
         treemap: {

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -1725,6 +1725,7 @@ treemapChart(chartsColumnData?: any, chartsRowData?: any){
     series: [{
       type: 'treemap',
       roam: false,
+      nodeClick: false,
       breadcrumb: {
         show: false
       },

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2448,7 +2448,7 @@
                             
                         </div>
                     </div>
-                    <div  [ngStyle]="{'display': ((bar || horizontalBar || pie || donut || map) && draggedColumns && draggedColumns?.length > 0 ? '' : 'none')}" class="row align-items-center">
+                    <div  [ngStyle]="{'display': ((bar || horizontalBar || pie || donut || treemap || map) && draggedColumns && draggedColumns?.length > 0 ? '' : 'none')}" class="row align-items-center">
                                                 <div class="col-lg-2 col-md-2 col-sm-2 col-xl-2 p-0" style="overflow: auto; white-space: nowrap;">
                                                    <div class="card-area d-flex gap-2">
                                                        <label for="inputName" class="form-control mb-0 border">Hierarchy</label>
@@ -2490,7 +2490,7 @@
                         <option *ngIf="!(guage)" value="echart">EChart</option>
                     </select>
                 </div> -->
-                @if((pie || bar || horizontalBar|| donut || map) && draggedDrillDownColumns && draggedDrillDownColumns.length > 0){
+                @if((pie || bar || horizontalBar|| donut || treemap || map) && draggedDrillDownColumns && draggedDrillDownColumns.length > 0){
                                     <div class="col-lg-3 col-md-3 p-1">
                                         <button class="btn btn-primary p-1" (click)="goDrillDownBack()">
                                             <img src="./assets/images/Tiled view sheet icons/Drill-Down.png" alt="logo" class="w-5 h-5"> </button>

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -2234,7 +2234,7 @@ sheetSave(isDashboardTransfer?: boolean){
     //  bandColor2 = this.color2;
     }
 
-  if ([6, 14, 24, 10].includes(this.chartId) && this.originalData && this.drillDownIndex > 0 && this.drillDownObject.length > 0) {
+  if ([6, 14, 24, 10, 18].includes(this.chartId) && this.originalData && this.drillDownIndex > 0 && this.drillDownObject.length > 0) {
     tablePreviewRow = _.cloneDeep(this.tablePreviewRow);
     tablePreviewRow[0].result_data = this.originalData.data;
 
@@ -5193,6 +5193,15 @@ customizechangeChartPlugin() {
           }
         }
         else if(this.donut){//pie
+          if(!this.originalData){
+            this.originalData = {categories: this.chartsColumnData , data:this.chartsRowData, chartOptions: chartOptions };
+          } else{
+            this.originalData.categories = this.chartsColumnData;
+            this.originalData.data = this.chartsRowData;
+            this.originalData.chartOptions = chartOptions;
+          }
+        }
+        else if(this.treemap){//treemap
           if(!this.originalData){
             this.originalData = {categories: this.chartsColumnData , data:this.chartsRowData, chartOptions: chartOptions };
           } else{


### PR DESCRIPTION
## Summary
- enable treemap drilldown in ApexCharts by wiring data point selection to drilldown state
- allow treemap nodes in ECharts to emit drilldown events and prevent default node zoom
- reset and expose treemap drilldowns via Sheets component, including hierarchy field and data preservation for back navigation

## Testing
- `npm test` *(fails: ng: not found)*


------
https://chatgpt.com/codex/tasks/task_b_68b729e896a48320b8139deb3c9f8f52