### PR TITLE
feat: integrate Gemini smart dashboard in workbench

### DIFF
--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1095,6 +1095,11 @@ deleteUser(id:any){
       this.accessToken = JSON.parse( currentUser! )['Token'];
       return this.http.get<any>(`${environment.apiUrl}/open_ai_dashbaord/`+id+'/'+this.accessToken);
     }
+    buildSampleGeminiDashboard(id: number){
+      const currentUser = localStorage.getItem('currentUser');
+      this.accessToken = JSON.parse(currentUser!)['Token'];
+      return this.http.get<any>(`${environment.apiUrl}/gemini_dashbaord/`+id+'/'+this.accessToken);
+    }
     buildSampleSalesforceDashbaord(id : number){
       const currentUser = localStorage.getItem( 'currentUser' );
       this.accessToken = JSON.parse( currentUser! )['Token'];

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -2126,7 +2126,24 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
           }else if(this.datasourceSwitchUI){
             this.switchDatabase();
           }else{
-            this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+            Swal.fire({
+              position: "center",
+              iconHtml: '<img src="./assets/images/copilot.gif">',
+              title: "Create smart dashboard from your data with just one click?",
+              showConfirmButton: true,
+              showCancelButton: true,
+              confirmButtonText: 'Yes',
+              cancelButtonText: 'Skip',
+              customClass: {
+                icon: 'no-icon-bg',
+              }
+            }).then((result) => {
+              if (result.isConfirmed) {
+                this.templateDashboardService.buildSampleGeminiDashboard(this.container, this.databaseId);
+              } else {
+                this.router.navigate(['/analytify/database-connection/tables/'+encodedId]);
+              }
+            });
           }
         }
       }, error:(error)=>{
@@ -2656,6 +2673,9 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
           break;
         case 'connectwise':
           this.templateDashboardService.buildSampleConnectWiseDashboard(this.container, this.databaseId, dashboardData);
+          break;
+        case 'gemini':
+          this.templateDashboardService.buildSampleGeminiDashboard(this.container, this.databaseId, dashboardData);
           break;
       }
     }
@@ -3705,6 +3725,8 @@ connectGoogleSheets(){
       request$ = this.workbechService.buildSamplePaxDashboard(database.hierarchy_id);
     }else if(database.server_type === 'BAMBOOHR'){
       request$ = this.workbechService.buildSampleBambooHRDashboard(database.hierarchy_id);
+    }else if(database.server_type === 'GEMINI'){
+      request$ = this.workbechService.buildSampleGeminiDashboard(database.hierarchy_id);
     }else{
       request$ = this.workbechService.createSmartDashboard(database.hierarchy_id);
     }
@@ -3751,7 +3773,7 @@ connectGoogleSheets(){
             this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'GEMINI':
-            this.templateDashboardService.buildSampleOpenAIDashboard(this.container, database.hierarchy_id, responce);
+            this.createSmartDashboard(responce,'gemini');
             break;
         }
       },

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -1083,6 +1083,46 @@ export class TemplateDashboardService {
       })
     }
   }
+  buildSampleGeminiDashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
+    const componentRef =container.createComponent(InsightEchartComponent);
+    this.echartInstance = componentRef.instance;
+
+    const handleResponse = (responce: any) => {
+      const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+      queries.forEach((query: any) => {
+        const obj ={
+          query_set_id:query.queryset_id,
+          hierarchy_id:query.hierarchy_id,
+          joining_tables: query.joining_tables,
+          join_type:query.join_type,
+          joining_conditions:query.joining_conditions,
+          dragged_array: {dragged_array:query.dragged_array,dragged_array_indexing:{}},
+          is_smart_dashboard:true
+        } as any
+          this.workbechService.joiningTablesTest(obj).subscribe({next: () => {
+              },
+              error: (error) => {
+                this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+                console.log(error);
+              }
+            }
+          )
+      });
+      this.buildDashboardResponseData(responce);
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleGeminiDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          console.log(error);
+        }
+      })
+    }
+  }
 buildSampleTallyDashboard(container: ViewContainerRef, databaseId: any, responceData?: any) {
   const componentRef = container.createComponent(InsightEchartComponent);
   this.echartInstance = componentRef.instance;


### PR DESCRIPTION
## Summary
- add Gemini smart dashboard API call in workbench service
- build Gemini smart dashboard via template service
- hook Gemini dashboards into workbench flow with popup prompt

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden for @angular-devkit/build-angular)*

------
https://chatgpt.com/codex/tasks/task_b_68be2f70de4083208e9e69b9f2a77718