### PR TITLE
feat: add sunburst echart with drilldown

### DIFF
--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -1280,6 +1280,45 @@ donutChart(chartsColumnData?:any[],chartsRowData?:any[]){
   };
   return this.chartOptions;
 }
+
+sunburstChart(chartsColumnData?: any[], chartsRowData?: any[]) {
+  if (chartsColumnData && chartsRowData) {
+    this.chartsColumnData = chartsColumnData;
+    this.chartsRowData = chartsRowData;
+  }
+  const combinedArray = this.chartsRowData.map((value: any, index: number) => ({
+    value: value,
+    name: this.chartsColumnData[index]
+  }));
+  this.chartOptions = {
+    backgroundColor: this.backgroundColor,
+    color: this.isMeasureDistribution ? this.setColorsOnRanges(this.chartsRowData) : this.selectedColorScheme,
+    tooltip: {
+      trigger: 'item',
+      formatter: (params: any) => params.name + ' : ' + this.formatNumber(params.value)
+    },
+    legend: {
+      bottom: this.bottomLegend,
+      left: this.leftLegend,
+      orient: this.legendOrient,
+      right: this.rightLegend,
+      top: this.topLegend,
+      type: 'scroll',
+      show: this.legendSwitch
+    },
+    series: [
+      {
+        type: 'sunburst',
+        radius: [0, '90%'],
+        data: combinedArray,
+        label: {
+          show: this.dataLabels
+        }
+      }
+    ]
+  };
+  return this.chartOptions;
+}
 barLinechartFromGenieDashboard(dualAxisColumnData?:any, dualAxisRowData?:any){
   this.dualAxisColumnData = dualAxisColumnData;
   this.dualAxisRowData = dualAxisRowData;
@@ -2152,6 +2191,9 @@ chartInitialize(){
   else if(this.chartType === 'donut'){
     this.donutChart();
   }
+  else if(this.chartType === 'sunburst'){
+    this.sunburstChart();
+  }
   else if(this.chartType === 'barline'){
     this.barLineChart();
   }
@@ -2460,7 +2502,7 @@ chartInitialize(){
     // }
 
     if (changes['isMeasureDistribution'] || changes['measureColorRanges']) {
-      if (['bar', 'pie', 'donut', 'funnel', 'horizontalBar','treemap'].includes(this.chartType)) {
+      if (['bar', 'pie', 'donut', 'funnel', 'horizontalBar','treemap','sunburst'].includes(this.chartType)) {
         this.setMeasureRangeColors();
       }
     }
@@ -3491,7 +3533,7 @@ radarDistributionSetOptions() {
   }
   }
   legendSwitchSetOptions(){
-    if(this.chartType === 'donut' || this.chartType === 'pie' || this.chartType === 'radar'){
+    if(this.chartType === 'donut' || this.chartType === 'pie' || this.chartType === 'radar' || this.chartType === 'sunburst'){
       let obj ={
         legend :{
             show: this.legendSwitch
@@ -3502,7 +3544,7 @@ radarDistributionSetOptions() {
     }
   }
   dataLabelsSetOptions(){
-    if(this.chartType === 'donut' || this.chartType === 'pie' || this.chartType === 'treemap'){
+    if(this.chartType === 'donut' || this.chartType === 'pie' || this.chartType === 'treemap' || this.chartType === 'sunburst'){
       let obj ={
         series :[{
           label:{
@@ -3546,8 +3588,8 @@ radarDistributionSetOptions() {
        this.chartOptions.color = this.isDistributed ? this.selectedColorScheme : this.color;
     } else if(this.chartType === 'stocked'
        || this.chartType === 'sidebyside' || this.chartType === 'hgrouped' || this.chartType === 'hstocked' ||  
-       this.chartType === 'multiline' || this.chartType === 'pie' || this.chartType === 'donut' || 
-       this.chartType === 'calendar'){
+       this.chartType === 'multiline' || this.chartType === 'pie' || this.chartType === 'donut' ||
+       this.chartType === 'sunburst' || this.chartType === 'calendar'){
       let obj ={
         color:this.selectedColorScheme
        }
@@ -3724,7 +3766,7 @@ radarDistributionSetOptions() {
       this.chartOptions = { ...this.chartOptions, ...obj };
   }
   legendsAllignmentSetOptions(){
-    if(this.chartType === 'pie' || this.chartType === 'donut'){
+    if(this.chartType === 'pie' || this.chartType === 'donut' || this.chartType === 'sunburst'){
     if(this.legendsAllignment === 'top'){
     let obj ={
       legend :{

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -2715,6 +2715,16 @@
                     [measureColorRanges]="measureColorRanges"></app-insight-echart>
                 </div>
                 }
+            @else if(sunburst && chartId){
+                <div class="card-body">
+                    <app-insight-echart [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
+                    [backgroundColor]="backgroundColor" [legendSwitch]="legendSwitch" [dataLabels]="dataLabels"  [dataLabelsFontFamily]="dataLabelsFontFamily" [selectedColorScheme]="selectedColorScheme"
+                    [dataLabelsFontSize]="dataLabelsFontSize" [dataLabelsColor]="dataLabelsColor" [legendsAllignment]="legendsAllignment"  [displayUnits]="displayUnits" [decimalPlaces]="decimalPlaces" [prefix]="prefix" [suffix]="suffix"
+                    [isSheetSaveOrUpdate]="isSheetSaveOrUpdate" [drillDownIndex]="drillDownIndex" [draggedDrillDownColumns]="draggedDrillDownColumns"[drillDownObject]="drillDownObject"
+                    (setDrilldowns)="setDrilldowns($event)" (saveOrUpdateChart)="setChartOptions($event)" [leftLegend]="leftLegend" [topLegend]="topLegend" [rightLegend]="rightLegend" [bottomLegend]="bottomLegend" [legendOrient]="legendOrient" [isMeasureDistribution]="isMeasureDistribution"
+                    [measureColorRanges]="measureColorRanges"></app-insight-echart>
+                </div>
+                }
             @else if(line && chartId){
             <div class="card-body">
                 <app-insight-echart [isZoom]="isZoom" [isBold]="isBold" [dataLabelsFontPosition]="dataLabelsFontPosition" [chartType]="chartType"  [dimensionAlignment] = "dimensionAlignment" [chartsRowData]="chartsRowData" [chartsColumnData]="chartsColumnData"
@@ -3569,6 +3579,9 @@
                                                         <div class="col-3 px-2 mt-2" [ngClass]="{'disabled': (draggedRows?.length>1 || draggedColumns?.length>1) || ( draggedRows?.length<1 || draggedColumns?.length<1)}">
                                                             <a href="javascript:void(0);" triggers="hover" ngbTooltip="Treemap" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,18)"><img src="./assets/images/charts/treemap.svg" class="rounded-2 w-90 mrk-t border p-2 chart-icon" [ngClass]="{'active': treemap}"></a>
                                                         </div>
+                                                        <div class="col-3 px-2 mt-2" [ngClass]="{'disabled': (draggedRows?.length>1 || draggedColumns?.length>1) || ( draggedRows?.length<1 || draggedColumns?.length<1)}">
+                                                            <a href="javascript:void(0);" triggers="hover" ngbTooltip="Sunburst" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,19)"><img src="./assets/images/charts/treemap.svg" class="rounded-2 w-90 mrk-t border p-2 chart-icon" [ngClass]="{'active': sunburst}"></a>
+                                                        </div>
                                                         <div *ngIf="isApexCharts" class="col-3 px-2 mt-2" [ngClass]="{'disabled': (draggedRows?.length>1 || draggedColumns?.length>1) || ( draggedRows?.length<1 || draggedColumns?.length<1)}">
                                                             <a href="javascript:void(0);" triggers="hover" ngbTooltip="Radial" tooltipClass="tooltip-primary" (click)="chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,20)"><img src="./assets/images/charts/radial.svg" class="rounded-2 w-90 mrk-t border p-2 chart-icon" [ngClass]="{'active': radial}"></a>
                                                         </div>
@@ -3907,7 +3920,7 @@
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || (sunburst && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                           <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                             <button
                                                               ngbAccordionButton
@@ -4048,7 +4061,7 @@
                                                           </div>
                                                     </div>
 
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || funnel || kpi || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || (sunburst && chartId) || donut || funnel || kpi || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                             <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                               <button
                                                                 ngbAccordionButton
@@ -4191,7 +4204,7 @@
                                                             </div>
                                                     </div>
 
-                                                    <div *ngIf="!((pie && chartId) || donut || calendar || map || pivotTable || radial || (table && draggedRows?.length === 0))" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((pie && chartId) || (sunburst && chartId) || donut || calendar || map || pivotTable || radial || (table && draggedRows?.length === 0))" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -4675,7 +4688,7 @@
                                                         </div>
                                                     </div>
                                                   
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || (sunburst && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -4731,7 +4744,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="!((table && chartId) || (pie && chartId) || (sunburst && chartId) || donut || kpi || funnel || guage || calendar || radar || treemap || pivotTable || radial)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton
@@ -4829,7 +4842,7 @@
                                                                      ></ngx-colors>
                                                                 </div>
 
-                                                                <div *ngIf="!((table && chartId) || (pie && chartId)||donut||kpi||barLine||sidebyside||stocked||horizentalStocked||grouped||multiLine||heatMap || calendar || treemap) && ((!isDistributed && !isMeasureDistribution && (bar || horizontalBar || funnel)) || area || line || (radar && !isRadarDistribution) || guage)" class="d-flex align-items-center justify-content-between mb-1 flex-wrap gap-2">
+                                                                <div *ngIf="!((table && chartId) || (pie && chartId) || (sunburst && chartId)||donut||kpi||barLine||sidebyside||stocked||horizentalStocked||grouped||multiLine||heatMap || calendar || treemap) && ((!isDistributed && !isMeasureDistribution && (bar || horizontalBar || funnel)) || area || line || (radar && !isRadarDistribution) || guage)" class="d-flex align-items-center justify-content-between mb-1 flex-wrap gap-2">
                                                                     <div class=""> 
                                                                         <p>Chart</p>
                                                                     </div>
@@ -4923,7 +4936,7 @@
                                                                     [format]="'hex'">
                                                                     </ngx-colors>
                                                                 </div>
-                                                                <div *ngIf="isApexCharts && (xGridSwitch || yGridSwitch) && !((table && chartId) || (pie && chartId) || donut || kpi || funnel || heatMap || guage || treemap)" class="d-flex align-items-center justify-content-between mb-1 flex-wrap gap-2">
+                                                                <div *ngIf="isApexCharts && (xGridSwitch || yGridSwitch) && !((table && chartId) || (pie && chartId) || (sunburst && chartId) || donut || kpi || funnel || heatMap || guage || treemap)" class="d-flex align-items-center justify-content-between mb-1 flex-wrap gap-2">
                                                                     <div class=""> 
                                                                         <p >Grid Line</p>
                                                                     </div>
@@ -5194,7 +5207,7 @@
                                                           </div>
                                                         </div>
                                                     </div>
-                                                    <div *ngIf="((pie && chartId) || donut || radar || treemap)">
+                                                    <div *ngIf="((pie && chartId) || (sunburst && chartId) || donut || radar || treemap)">
                                                     <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                         <div class=""> 
                                                             <label class="mb-0" >Data Labels </label>
@@ -5207,7 +5220,7 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                                    <div *ngIf="((pie && chartId) || donut || radar || radial)">
+                                                    <div *ngIf="((pie && chartId) || (sunburst && chartId) || donut || radar || radial)">
                                                         <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                             <div class=""> 
                                                                 <label class="mb-0">Legends </label>
@@ -5368,7 +5381,7 @@
                                                         </div>
                                                     </div>
 
-                                                    <div *ngIf="((pie && chartId) || donut || bar || horizontalBar || treemap || map )  && draggedColumns && draggedColumns?.length == 1 && (dateList.includes(draggedColumns[0]['data_type']) || isLocationFeild)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
+                                                    <div *ngIf="((pie && chartId) || (sunburst && chartId) || donut || bar || horizontalBar || treemap || map )  && draggedColumns && draggedColumns?.length == 1 && (dateList.includes(draggedColumns[0]['data_type']) || isLocationFeild)" ngbAccordionItem  class="accordion-item mb-2 border rounded-2">
                                                         <h6 ngbAccordionHeader class="accordion-header" id="heading">
                                                           <button
                                                             ngbAccordionButton

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -889,9 +889,11 @@ try {
               this.calendar = false;
               this.map=false;
               this.treemap = false;
+    this.sunburst = false;
+              this.sunburst = false;
               this.radial = false;
               // this.tableDisplayPagination();
-            } else if(((this.pie || this.bar || this.horizontalBar || this.area || this.line || this.donut || this.funnel || this.calendar || this.radial || this.treemap) && (this.draggedColumns.length > 1 || this.draggedRows.length > 1))) {
+            } else if(((this.pie || this.bar || this.horizontalBar || this.area || this.line || this.donut || this.funnel || this.calendar || this.radial || this.treemap || this.sunburst) && (this.draggedColumns.length > 1 || this.draggedRows.length > 1))) {
               this.table = false;
               this.pivotTable = false;
               this.bar = false;
@@ -915,6 +917,8 @@ try {
               this.calendar = false;
               this.map = false;
               this.treemap = false;
+    this.sunburst = false;
+              this.sunburst = false;
               this.radial = false;
               // this.sidebysideBar();
               this.resetCustomizations();
@@ -1701,6 +1705,7 @@ try {
   guage = false;
   calendar = false;
   treemap = false;
+  sunburst = false;
   chartDisplay(table:boolean,bar:boolean,area:boolean,line:boolean,pie:boolean,sidebysideBar:boolean,stocked:boolean,barLine:boolean,
     horizentalStocked:boolean,grouped:boolean,multiLine:boolean,donut:boolean,radar:boolean,kpi:any,heatMap:any,funnel:any,guage:boolean,map:boolean,calendar:boolean,pivotTable:boolean,horizontalBar:boolean,chartId:any){
     this.table = table;
@@ -1725,15 +1730,16 @@ try {
     this.guage = guage;
     this.radial = (chartId === 20);
     this.treemap = (chartId === 18);
+    this.sunburst = (chartId === 19);
     this.map = map;
     this.calendar = calendar;
     if(this.bar){
       this.isHorizontalBar = false;
     }
-    if(this.bar || this.pie || this.donut || this.funnel){
+    if(this.bar || this.pie || this.donut || this.funnel || this.sunburst){
     this.updateMeasureColorRanges();
     }
-    if(!(this.bar|| this.horizontalBar || this.pie || this.donut)){
+    if(!(this.bar|| this.horizontalBar || this.pie || this.donut || this.sunburst)){
       this.draggedDrillDownColumns = [];
       this.drillDownObject = [];
       this.drillDownIndex = 0;
@@ -2221,6 +2227,7 @@ try {
       this.heatMap = false;
       this.radial = false;
       this.treemap = false;
+    this.sunburst = false;
       this.funnel = false;
       this.calendar = false;
       this.guage = false;
@@ -2287,7 +2294,7 @@ sheetSave(isDashboardTransfer?: boolean){
     //  bandColor2 = this.color2;
     }
 
-  if ([6, 14, 24, 10, 18].includes(this.chartId) && this.originalData && this.drillDownIndex > 0 && this.drillDownObject.length > 0) {
+  if ([6, 14, 24, 10, 18, 19].includes(this.chartId) && this.originalData && this.drillDownIndex > 0 && this.drillDownObject.length > 0) {
     tablePreviewRow = _.cloneDeep(this.tablePreviewRow);
     tablePreviewRow[0].result_data = this.originalData.data;
 
@@ -2820,6 +2827,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
     this.itemsPerPage = this.sheetResponce?.results?.items_per_page;
     if (isDashboardTransfer) {
@@ -2872,6 +2880,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
     this.pivotTableDatatransform(false, false, this.sheetResponce?.customizeOptions?.pivotConfig);
   }
@@ -2920,6 +2929,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
   }
   if(responce.chart_id == 29){
@@ -2948,6 +2958,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = true;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
     this.chartType = 'map';
   }
@@ -2978,6 +2989,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
   if(responce.chart_id == 14){
@@ -3007,6 +3019,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 24){
@@ -3034,6 +3047,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 13){
@@ -3061,6 +3075,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 17){
@@ -3088,6 +3103,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 7){
@@ -3114,6 +3130,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.map = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
     this.calendar = false;
  }
@@ -3142,6 +3159,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 4){
@@ -3168,6 +3186,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.guage = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
     this.calendar = false;
  }
@@ -3196,6 +3215,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 2){
@@ -3223,6 +3243,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.guage = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 3){
@@ -3250,6 +3271,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 8){
@@ -3277,6 +3299,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 10){
@@ -3304,6 +3327,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 26){
@@ -3330,6 +3354,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 18){
@@ -3382,6 +3407,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 28){
@@ -3409,6 +3435,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = false;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 11){
@@ -3435,6 +3462,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.map = false;
     this.calendar = true;
     this.treemap = false;
+    this.sunburst = false;
     this.radial = false;
  }
  if(responce.chart_id == 20){
@@ -3462,6 +3490,7 @@ this.isTopFilter = !this.dimetionMeasure.some((column: any) => column.top_bottom
     this.calendar = false;
     this.radial = true;
     this.treemap = false;
+    this.sunburst = false;
  }
  this.getDimensionAndMeasures();
  this.changeSelectedColumn();
@@ -4430,6 +4459,10 @@ routeConfigure(){
   } else if (chartType.includes("treemap")) {
     // Treemap
     this.chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,18);
+
+  } else if (chartType.includes("sunburst")) {
+    // Sunburst
+    this.chartDisplay(false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,false,19);
 
   } else if (chartType.includes("heat map")) {
     // Heat Map
@@ -6952,6 +6985,7 @@ customizechangeChartPlugin() {
       this.calendar = false;
       this.map = false;
       this.treemap = false;
+    this.sunburst = false;
       this.radial = false;
     }
     sortColumn : any = 'select';

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1225,7 +1225,7 @@
                   </div>
                 </div>
                  <div class="card-header d-flex justify-content-between p-1" [attr.style]="((item.data?.title || item['type'] === 'image') ? 'display: flex !important;' : 'display: none !important;')">
-                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18 || item['chartId'] === 20 || item['chartId'] === 28) &&
+                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18 || item['chartId'] === 20 || item['chartId'] === 28 || item['chartId'] === 19) &&
                   item['drillDownHierarchy'] && item['drillDownHierarchy'].length > 0){
                   <!-- <div class="col-lg-3 col-md-3"> -->
                   <button class="btn btn-primary " style="margin-right: 10px;" (click)="goDrillDownBack(item)"><i
@@ -1827,7 +1827,7 @@
                           ? 'center' 
                           : ''">
                 <div class="card-header d-flex justify-content-between p-1">
-                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18 || item['chartId'] === 20 || item['chartId'] === 28) &&
+                  @if((item['chartId'] === 6 || item['chartId'] === 14 || item['chartId'] === 24 || item['chartId'] === 10 || item['chartId'] === 29 || item['chartId'] === 18 || item['chartId'] === 20 || item['chartId'] === 28 || item['chartId'] === 19) &&
                   item['drillDownHierarchy'] && item['drillDownHierarchy'].length > 0){
                   <!-- <div class="col-lg-3 col-md-3"> -->
                   <button class="btn btn-primary " style="margin-right: 10px;" (click)="goDrillDownBack(item)"><i

--- a/src/app/services/chart-render.service.ts
+++ b/src/app/services/chart-render.service.ts
@@ -23,6 +23,7 @@ export interface ChartFlags {
   pivotTable: boolean;
   treemap: boolean;
   radial: boolean;
+  sunburst: boolean;
 }
 
 export interface ChartConfig {
@@ -55,6 +56,7 @@ export class ChartRenderService {
     pivotTable: false,
     treemap: false,
     radial: false,
+    sunburst: false,
   };
 
   private chartConfigMap: Record<number, ChartConfig> = {
@@ -77,6 +79,7 @@ export class ChartRenderService {
     11: { chartType: 'calendar', flags: { ...this.baseFlags, calendar: true } },
     18: { chartType: 'treemap', flags: { ...this.baseFlags, treemap: true } },
     20: { chartType: 'radial', flags: { ...this.baseFlags, radial: true } },
+    19: { chartType: 'sunburst', flags: { ...this.baseFlags, sunburst: true } },
   };
 
   getChartConfig(chartId: number): ChartConfig | undefined {

--- a/src/app/services/dashboard-transfer.service.ts
+++ b/src/app/services/dashboard-transfer.service.ts
@@ -214,7 +214,7 @@ export class DashboardTransferService {
      if (!chartOptions) chartOptions = {};
 
   if (isApexChart) {
-    if ([24, 10].includes(chartId)) {
+    if ([24, 10, 19].includes(chartId)) {
       chartOptions.series = multiSeriesChartData[0]?.data || [];
       chartOptions.labels = xAxisCategories;
     } else if (chartId == 28) {
@@ -402,7 +402,7 @@ export class DashboardTransferService {
 
       chartOptions.series[0].data = result;
       chartOptions = {...chartOptions};
-    } else if([24, 10, 27].includes(chartId)){
+    } else if([24, 10, 27, 19].includes(chartId)){
       let data: any[] = [];
       xAxisCategories.forEach((col: any, index: any) => {
         data.push({ value: multiSeriesChartData[0].data[index], name: col })


### PR DESCRIPTION
## Summary
- add SUNBURST (chart id 19) support and rendering options
- wire drilldown and legend/label controls for sunburst charts
- update services and dashboard components to recognise new chart type

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68be36e830c88320849031b96d729f94