### PR TITLE
feat: add Zoho smart dashboard support

### DIFF
--- a/src/app/components/workbench/database/database.component.ts
+++ b/src/app/components/workbench/database/database.component.ts
@@ -305,23 +305,22 @@ export class DatabaseComponent {
     if(currentUrl.includes('/analytify/database-connection/zoho/')){
       this.fromDatabasId = true;
       this.databaseId = +atob(route.snapshot.params['id']);
-      //     Swal.fire({
-      //   position: "center",
-      //   // icon: "question",
-      //   iconHtml: '<img src="./assets/images/copilot.gif">',
-      //   title: "Create smart dashboard from your data with just one click?",
-      //   showConfirmButton: true,
-      //   showCancelButton: true,
-      //   confirmButtonText: 'Yes',
-      //   cancelButtonText: 'No',
-      //   customClass: {
-      //     icon: 'no-icon-bg',
-      //   }
-      // }).then((result) => {
-      //   if (result.isConfirmed) {
-      //     this.templateDashboardService.buildSampleHubspotDashboard(this.container, this.databaseId);
-      //   }
-      // });
+      Swal.fire({
+        position: "center",
+        iconHtml: '<img src="./assets/images/copilot.gif">',
+        title: "Create smart dashboard from your data with just one click?",
+        showConfirmButton: true,
+        showCancelButton: true,
+        confirmButtonText: 'Yes',
+        cancelButtonText: 'No',
+        customClass: {
+          icon: 'no-icon-bg',
+        }
+      }).then((result) => {
+        if (result.isConfirmed) {
+          this.templateDashboardService.buildSampleZohoDashboard(this.container, this.databaseId);
+        }
+      });
     } if(currentUrl.includes('/analytify/database-connection/jira/')){
       this.fromDatabasId = true;
       this.databaseId = +atob(route.snapshot.params['id']);

--- a/src/app/components/workbench/workbench.service.ts
+++ b/src/app/components/workbench/workbench.service.ts
@@ -1135,6 +1135,11 @@ deleteUser(id:any){
       this.accessToken = JSON.parse( currentUser! )['Token'];
       return this.http.get<any>(`${environment.apiUrl}/salesforce_dashbaord/`+id+'/'+this.accessToken);
     }
+    buildSampleZohoDashboard(id: number){
+      const currentUser = localStorage.getItem('currentUser');
+      this.accessToken = JSON.parse(currentUser!)['Token'];
+      return this.http.get<any>(`${environment.apiUrl}/zoho_dashbaord/`+id+'/'+this.accessToken);
+    }
     buildSampleTallyDashboard(id: number) {
       const currentUser = localStorage.getItem('currentUser');
       this.accessToken = JSON.parse(currentUser!)['Token'];

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -58,7 +58,7 @@ export class WorkbenchComponent implements OnInit{
   fileId:any;
 
   databaseType:any;
-  smartDashboardSources = ['CONNECTWISE','SHOPIFY','HALOPS','OPEN_AI','HUBSPOT','NINJA','IMMYBOT','QUICKBOOKS','SALESFORCE','TALLY','PAX8','BAMBOOHR','GEMINI'];
+  smartDashboardSources = ['CONNECTWISE','SHOPIFY','HALOPS','OPEN_AI','HUBSPOT','NINJA','IMMYBOT','QUICKBOOKS','SALESFORCE','ZOHO','TALLY','PAX8','BAMBOOHR','GEMINI'];
   openPostgreSqlForm= false;
   openMySqlForm = false;
   openConnectWiseForm = false;
@@ -4008,6 +4008,8 @@ connectGoogleSheets(){
       request$ = this.workbechService.buildSampleBambooHRDashboard(database.hierarchy_id);
     }else if(database.server_type === 'GEMINI'){
       request$ = this.workbechService.buildSampleGeminiDashboard(database.hierarchy_id);
+    }else if(database.server_type === 'ZOHO'){
+      request$ = this.workbechService.buildSampleZohoDashboard(database.hierarchy_id);
     }else{
       request$ = this.workbechService.createSmartDashboard(database.hierarchy_id);
     }
@@ -4025,6 +4027,9 @@ connectGoogleSheets(){
             break;
           case 'QUICKBOOKS':
             this.templateDashboardService.buildSampleQuickbooksDashboard(this.container, database.hierarchy_id, responce);
+            break;
+          case 'ZOHO':
+            this.templateDashboardService.buildSampleZohoDashboard(this.container, database.hierarchy_id, responce);
             break;
           case 'IMMYBOT':
             this.templateDashboardService.buildSampleImmybotDashboard(this.container, database.hierarchy_id, responce);

--- a/src/app/services/template-dashboard.service.ts
+++ b/src/app/services/template-dashboard.service.ts
@@ -1043,6 +1043,46 @@ export class TemplateDashboardService {
     }
   }
 
+  buildSampleZohoDashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
+    const componentRef = container.createComponent(InsightEchartComponent);
+    this.echartInstance = componentRef.instance;
+
+    const handleResponse = (responce: any) => {
+      const queries = Array.isArray(responce.datasource_query) ? responce.datasource_query : [responce.datasource_query];
+      queries.forEach((query: any) => {
+        const obj = {
+          query_set_id: query.queryset_id,
+          hierarchy_id: query.hierarchy_id,
+          joining_tables: query.joining_tables,
+          join_type: query.join_type,
+          joining_conditions: query.joining_conditions,
+          dragged_array: { dragged_array: query.dragged_array, dragged_array_indexing: {} },
+          is_smart_dashboard:true
+        } as any;
+        this.workbechService.joiningTablesTest(obj).subscribe({
+          next: () => {},
+          error: (error) => {
+            this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+            console.log(error);
+          }
+        })
+      });
+      this.buildDashboardResponseData(responce);
+    };
+
+    if(responceData){
+      handleResponse(responceData);
+    } else {
+      this.workbechService.buildSampleZohoDashboard(databaseId).subscribe({
+        next: handleResponse,
+        error: (error) => {
+          this.toasterservice.error(error.error.message,'error',{ positionClass: 'toast-center-center'})
+          console.log(error);
+        }
+      })
+    }
+  }
+
   buildSampleOpenAIDashboard(container: ViewContainerRef , databaseId: any, responceData?: any){
     const componentRef =container.createComponent(InsightEchartComponent);
     this.echartInstance = componentRef.instance;


### PR DESCRIPTION
## Summary
- add Zoho to Smart Dashboard sources and handle its dashboard build flow
- wire up Zoho Smart Dashboard creation service and template logic
- prompt users to generate a Zoho Smart Dashboard after connecting

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c125938f9883209fc80baa8dd5c686