### PR TITLE
refactor: consolidate Zoho scope change handler

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -4945,7 +4945,12 @@
           <label [ngClass]="{'error-label': zohoScopeError}" class="form-label">
             Scopes <span class="text-danger">*</span>
           </label>
-          <ng-multiselect-dropdown [data]="zohoScopes" [(ngModel)]="selectedZohoScopes" [ngModelOptions]="{standalone: true}" [settings]="hubspotDropdownSettings" (onSelect)="onZohoScopeChange()" (onDeSelect)="onZohoScopeChange()" (onSelectAll)="onZohoScopeChange()" (onDeSelectAll)="onZohoScopeChange()">
+          <ng-multiselect-dropdown
+            [data]="zohoScopes"
+            [(ngModel)]="selectedZohoScopes"
+            [ngModelOptions]="{standalone: true}"
+            [settings]="hubspotDropdownSettings"
+            (ngModelChange)="onZohoScopeChange($event)">
           </ng-multiselect-dropdown>
         </div>
 

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -1723,8 +1723,9 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
     this.zohoRedirectURLError = !this.zohoRedirectURL;
   }
 
-  onZohoScopeChange(): void {
-    this.zohoScopeError = this.selectedZohoScopes.length <= 0;
+  onZohoScopeChange(scopes: string[]): void {
+    this.selectedZohoScopes = scopes;
+    this.zohoScopeError = !scopes || scopes.length === 0;
   }
   
     shopifySignIn(){


### PR DESCRIPTION
## Summary
- streamline Zoho scopes dropdown to use ngModelChange instead of multiple selection events
- recompute Zoho scope error state from ngModelChange handler

## Testing
- `node -e 'let selectedZohoScopes=["CRM"]; let zohoScopeError=true; function onZohoScopeChange(scopes){selectedZohoScopes=scopes; zohoScopeError=!scopes||scopes.length===0;} onZohoScopeChange(["CRM","Desk"]); console.log("selected", selectedZohoScopes, "error", zohoScopeError);'`
- `npm test --silent` *(fails: ng not found)*
- `npm install --no-audit --no-fund --legacy-peer-deps` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68c5b84a1a288320802a78c167aad712