### PR TITLE
Add wordcloud chart handling in sheets dashboard

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1389,12 +1389,21 @@
                 </div>
                 }
                 @if(item['isEChart'] && !(item['chartId']=== 29 || item['chartId']=== 25 || item['chartId']=== 1 ||
-                item['chartId']=== 9) ){
+                item['chartId']=== 9 || item['chartId']=== 21) ){
                 <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
                   [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
                   <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
                     (chartClick)="onEChartClick($event,item)" class="echart-charts"
                     [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
+                </div>
+                
+                } @else if(item['isEChart'] && item['chartId'] === 21){
+                <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                  <app-wordcloud-chart
+                    [chartsColumnData]="item['wordcloudData'] ?? item['echartOptions']?.series?.[0]?.data ?? []"
+                    [chartsRowData]="item['wordcloudData'] ?? item['echartOptions']?.series?.[0]?.data ?? []"
+                    [customOptions]="item['customizeOptions']?.wordcloudOptions || item['customizeOptions']">
+                  </app-wordcloud-chart>
                 </div>
 
                 } @else if(item['isEChart'] && item['chartId']=== 29){
@@ -1916,12 +1925,21 @@
                 </div>
                 }
                   @if(item['isEChart'] && !(item['chartId']=== 29 || item['chartId']=== 25 || item['chartId']=== 1 ||
-                  item['chartId']=== 9) ){
+                  item['chartId']=== 9 || item['chartId']=== 21) ){
                   <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }"
                     [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight, 'overflow-y': 'auto'} : {}">
                     <div id="echartsBar{{item['sheetId']}}" echarts [options]="item['echartOptions']"
                       (chartClick)="onEChartClick($event,item)" class="echart-charts"
                       [ngStyle]="item['chartId'] === 11 ? {'height': calendarTotalHeight} : ([14, 27].includes(item['chartId']) ? {'height': item['customizeOptions']?.hBarHeight ?? null} : {})"></div>
+                  </div>
+
+                  } @else if(item['isEChart'] && item['chartId'] === 21){
+                  <div class="card-body p-1" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                    <app-wordcloud-chart
+                      [chartsColumnData]="item['wordcloudData'] ?? item['echartOptions']?.series?.[0]?.data ?? []"
+                      [chartsRowData]="item['wordcloudData'] ?? item['echartOptions']?.series?.[0]?.data ?? []"
+                      [customOptions]="item['customizeOptions']?.wordcloudOptions || item['customizeOptions']">
+                    </app-wordcloud-chart>
                   </div>
 
                   } @else if(item['isEChart'] && item['chartId']=== 29){

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -49,6 +49,7 @@ import { SharedService } from '../../../shared/services/shared.service';
 // import { series } from '../../charts/apexcharts/data';
 import { tap, takeUntil } from 'rxjs/operators'; 
 import { InsightEchartComponent } from '../insight-echart/insight-echart.component';
+import { WordcloudChartComponent } from '../wordcloud-chart/wordcloud-chart.component';
 import iconsData from '../../../../assets/iconfonts/font-awesome/metadata/icons.json';
 import { FilterIconsPipe } from '../../../shared/pipes/iconsFilterPipe';
 import 'pivottable';
@@ -133,7 +134,7 @@ export class CustomVirtualScrollStrategy extends FixedSizeVirtualScrollStrategy 
   imports: [NgxEchartsModule,SharedModule,NgbModule,CommonModule,ResizableModule,GridsterModule,
     GridsterItemComponent,GridsterComponent,NgApexchartsModule,CdkDropListGroup, NgSelectModule,
     CdkDropList, CdkDrag,ChartsStoreComponent,FormsModule, MatTabsModule , CKEditorModule , InsightsButtonComponent,
-    NgxPaginationModule,NgSelectModule, InsightEchartComponent,SharedModule,FilterIconsPipe,FormatMeasurePipe,ScrollingModule,TestPipe,SanitizeHtmlPipe,SafeUrlPipe,GenieAiqDashboardComponent],
+    NgxPaginationModule,NgSelectModule, InsightEchartComponent,WordcloudChartComponent,SharedModule,FilterIconsPipe,FormatMeasurePipe,ScrollingModule,TestPipe,SanitizeHtmlPipe,SafeUrlPipe,GenieAiqDashboardComponent],
   templateUrl: './sheetsdashboard.component.html',
   styleUrl: './sheetsdashboard.component.scss',
 })
@@ -393,9 +394,11 @@ export class SheetsdashboardComponent implements OnDestroy {
   }
   options!: GridsterConfig;
 
-  dashboard!: Array<GridsterItem & { sheetId?: number ,data?: any, chartType?: any,   chartOptions?: ApexOptions, echartOptions : any, chartInstance?: ApexCharts,chartData?: any[],tableData?: { headers: any[], rows: any[], banding: any, color1: any, color2: any, tableItemsPerPage : any, tableTotalItems : any ,tablePage : number  }, numberFormat?: {donutDecimalPlaces: any,decimalPlaces: any,displayUnits: any,prefix:any,suffix:any}, pivotData?:any
+  dashboard!: Array<GridsterItem & { sheetId?: number ,data?: any, chartType?: any,   chartOptions?: ApexOptions, echartOptions : any, chartInstance?: ApexCharts,chartData?: any[],tableData?: { headers: any[], rows: any[], banding: any, color1: any, color2: any, tableItemsPerPage : any, tableTotalItems : any ,tablePage : number  }, numberFormat?: {donutDecimalPlaces: any,decimalPlaces: any,displayUnits: any,prefix:any,suffix:any}, pivotData?:any,
+    wordcloudData?: any[]
   }>;
-  dashboardTest!: Array<GridsterItem & { sheetId?: number ,data?: any, chartType?: any,   chartOptions?: ApexOptions, echartOptions : any, chartInstance?: ApexCharts,chartData?: any[],tableData?: { headers: any[], rows: any[], banding: any, color1: any, color2: any, tableItemsPerPage : any, tableTotalItems : any ,tablePage : number  }, numberFormat?: {donutDecimalPlaces: any,decimalPlaces: any,displayUnits: any,prefix:any,suffix:any}, pivotData?:any
+  dashboardTest!: Array<GridsterItem & { sheetId?: number ,data?: any, chartType?: any,   chartOptions?: ApexOptions, echartOptions : any, chartInstance?: ApexCharts,chartData?: any[],tableData?: { headers: any[], rows: any[], banding: any, color1: any, color2: any, tableItemsPerPage : any, tableTotalItems : any ,tablePage : number  }, numberFormat?: {donutDecimalPlaces: any,decimalPlaces: any,displayUnits: any,prefix:any,suffix:any}, pivotData?:any,
+    wordcloudData?: any[]
   }>;
   dashboardNew!: Array<GridsterItem & { data?: any,   chartOptions?: ApexOptions,  chartInstance?: ApexCharts,chartData?: any[],tableData?: { headers: any[], rows: any[], banding: any, color1: any, color2: any, tableItemsPerPage : any, tableTotalItems : any  }
   }>;
@@ -1078,6 +1081,9 @@ export class SheetsdashboardComponent implements OnDestroy {
       // console.log('Before sanitization:', sheet.data?.sheetTagName);
       if(sheet.data?.sheetTagName){
         this.sheetTagTitle[sheet.data?.title] = this.sanitizer.bypassSecurityTrustHtml(sheet.data?.sheetTagName);
+      }
+      if(sheet.chartId == 21 && sheet.echartOptions?.series?.[0]?.data){
+        sheet.wordcloudData = _.cloneDeep(sheet.echartOptions.series[0].data);
       }
       if((sheet && sheet.chartOptions && sheet.chartOptions.chart)) {
       sheet.chartOptions.chart.events = {
@@ -1931,6 +1937,13 @@ export class SheetsdashboardComponent implements OnDestroy {
           item1.chartOptions = item1['originalData'].chartOptions;
           delete item1['originalData'];
         }
+        if(item1.chartId == '21' && item1['originalData']){//wordcloud
+          if(item1.isEChart){
+            item1.echartOptions = item1['originalData'].chartOptions;
+            item1.wordcloudData = _.cloneDeep(item1.echartOptions?.series?.[0]?.data || []);
+          }
+          delete item1['originalData'];
+        }
         if(item1.chartId == '18' && item1['originalData']){//treemap
           if(item1.isEChart){
             item1.echartOptions = item1['originalData'].chartOptions;
@@ -2351,7 +2364,8 @@ allowDrop(ev : any): void {
         isDrillDownData: copy.isDrillDownData,
         numberFormat: copy.numberFormat,
         customizeOptions: copy.customizeOptions,
-        pivotData: copy.pivotData
+        pivotData: copy.pivotData,
+        wordcloudData: copy.chartId === 21 ? _.cloneDeep(copy.chartOptions?.series?.[0]?.data || []) : copy.wordcloudData
       };
       // if (element.chartId == '18' && element.echartOptions) {
       //   const nf = element.numberFormat || {};
@@ -4201,6 +4215,53 @@ setDashboardSheetData(item:any , isFilter : boolean , onApplyFilterClick : boole
               item1.numberFormat?.suffix ?? ''
             )}`
         };
+      }
+      if((item.chart_id == '21' || item.chartId == '21' && (isFilter || isDrillDown)) || (item1.chartId == '21' && isDrillThrough)){
+        if(switchDb){
+          item1.databaseId = item.databaseId;
+        }
+        if(item1.isEChart && item1.echartOptions?.series?.length){
+          if(!item1.originalData && !isLiveReloadData && !switchDb){
+            item1['originalData'] = _.cloneDeep({chartOptions: item1.echartOptions});
+          }
+          if(onApplyFilterClick && ((item1.drillDownHierarchy && item1.drillDownHierarchy.length > 0) || item1.drillDownIndex)){
+            item1.drillDownIndex = 0;
+            item1.drillDownObject = [];
+          }
+          const normalizeLabel = (val: any) => {
+            if (val === null || val === undefined) {
+              return 'null';
+            }
+            const label = String(val).trim();
+            return label === '' ? 'null' : label;
+          };
+          const dimensions: Dimension[] = this.filteredColumnData;
+          let categories: string[] = [];
+          if(dimensions?.length){
+            if(dimensions.length === 1){
+              categories = (dimensions[0].values || []).map(normalizeLabel);
+            } else {
+              categories = this.flattenDimensions(dimensions).map((value: string) => normalizeLabel(value));
+            }
+          }
+          const aggregatedMeasures = this.filteredRowData.reduce((acc: number[], row: any) => {
+            row?.data?.forEach((val: any, index: number) => {
+              const numericValue = typeof val === 'number' ? val : parseFloat(val);
+              const safeValue = isNaN(numericValue) ? 0 : numericValue;
+              acc[index] = (acc[index] ?? 0) + safeValue;
+            });
+            return acc;
+          }, [] as number[]);
+          const wordcloudData = categories.map((label: string, index: number) => ({
+            name: label,
+            value: aggregatedMeasures[index] ?? 0
+          }));
+          item1.wordcloudData = wordcloudData;
+          item1.echartOptions.series[0].data = wordcloudData;
+          item1.echartOptions = {
+            ...item1.echartOptions
+          };
+        }
       }
       if((item.chart_id == '18' || item.chartId == '18' && (isFilter || isDrillDown)) || (item1.chartId == '18' && isDrillThrough)){//treemap
         if(switchDb){


### PR DESCRIPTION
## Summary
- register the standalone wordcloud component in the sheets dashboard module and extend tracked dashboard item data with cached wordcloud series
- ensure dashboard data refresh, original state resets, and filter workflows clone and normalize wordcloud series data for chart id 21
- render the new wordcloud chart tiles in the dashboard template using the dedicated component alongside the existing ECharts handling

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68c936a19e988320a117d41ca49463f2