### PR TITLE
Fix Jira scopes select-all validation

### DIFF
--- a/src/app/components/workbench/workbench/workbench.component.html
+++ b/src/app/components/workbench/workbench/workbench.component.html
@@ -2212,9 +2212,19 @@
                         <label [ngClass]="{'error-label': jiraRedirectURLError}" class="col-form-label">Redirect URL <span class="text-danger ms-1">*</span></label>
                         <input [ngClass]="{'error-input': jiraRedirectURLError}" type="text" class="form-control" [(ngModel)]="jiraRedirectURL" [ngModelOptions]="{standalone: true}" (input)="jiraRedirectURLInput()">
                       </div>
+                      <div class="form-group">
+                        <label [ngClass]="{'error-label': jiraScopeError}" class="col-form-label">Scopes <span class="text-danger ms-1">*</span></label>
+                        <ng-multiselect-dropdown
+                          [data]="jiraScopes"
+                          [(ngModel)]="selectedJiraScopes"
+                          [ngModelOptions]="{standalone: true}"
+                          [settings]="jiraDropdownSettings"
+                          (ngModelChange)="onJiraScopeChange($event)">
+                        </ng-multiselect-dropdown>
+                      </div>
                       <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" (click)="gotoNewConnections()">Close</button>
-                        <button type="button" class="btn btn-primary" (click)="jiraSignIn()" [disabled]="(jiraClientSecretError || displayNameError || jiraClientIdError || jiraRedirectURLError) || !(jiraClientSecret && jiraClientId && displayName && jiraRedirectURL)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+                        <button type="button" class="btn btn-primary" (click)="jiraSignIn()" [disabled]="(jiraScopeError || jiraClientSecretError || displayNameError || jiraClientIdError || jiraRedirectURLError) || !(selectedJiraScopes.length>0 && jiraClientSecret && jiraClientId && displayName && jiraRedirectURL)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
                       </div>
                     </form>
                   </div>
@@ -2233,6 +2243,7 @@
                       <li><span class="mb-0"><strong>Client Secret:</strong> Application secret.</span></li>
                       <li><span class="mb-0"><strong>Redirect URI:</strong> Redirect URL configured in Jira.</span></li>
                       <li><span class="mb-0"><strong>Display Name:</strong> A user-friendly name for the connection.</span></li>
+                      <li><span class="mb-0"><strong>Scopes:</strong> Required Jira permissions (manage:jira-configuration, manage:jira-project, manage:jira-webhook, read:jira-user, read:jira-work).</span></li>
                     </ul>
                   </div>
                 </div>
@@ -5514,6 +5525,20 @@
         </div>
 
         <div class="mb-3">
+          <label [ngClass]="{'error-label': jiraScopeError}" class="form-label d-inline-block me-1">
+            Scopes <span class="text-danger">*</span>
+          </label>
+          <span class="text-muted" style="display:inline-block;">(Select the required Jira scopes in this field)</span>
+          <ng-multiselect-dropdown
+            [data]="jiraScopes"
+            [(ngModel)]="selectedJiraScopes"
+            [ngModelOptions]="{standalone: true}"
+            [settings]="jiraDropdownSettings"
+            (ngModelChange)="onJiraScopeChange($event)">
+          </ng-multiselect-dropdown>
+        </div>
+
+        <div class="mb-3">
           <label class="form-label">Description </label>
           <span class="text-muted" style="display:inline-block;">(Enter your description)</span>
           <input type="text" class="form-control forms-light w-100" [(ngModel)]="connectionDescription" [ngModelOptions]="{standalone: true}" placeholder="Enter your description">
@@ -5521,7 +5546,7 @@
 
         <div class="d-flex justify-content-end gap-2 mt-3">
           <button type="button" class="btn btn-secondary animate-button" (click)="goBackToSubCategories()">Close</button>
-          <button type="submit" class="btn btn-primary me-3 animate-button" [disabled]="(jiraClientSecretError || displayNameError || jiraClientIdError || jiraRedirectURLError) || !(jiraClientSecret && jiraClientId && displayName && jiraRedirectURL)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
+          <button type="submit" class="btn btn-primary me-3 animate-button" [disabled]="(jiraScopeError || jiraClientSecretError || displayNameError || jiraClientIdError || jiraRedirectURLError) || !(selectedJiraScopes.length>0 && jiraClientSecret && jiraClientId && displayName && jiraRedirectURL)">{{ iscrossDbSelect ? 'Connect & Move' : 'Connect' }}</button>
         </div>
 
       </form>

--- a/src/app/components/workbench/workbench/workbench.component.ts
+++ b/src/app/components/workbench/workbench/workbench.component.ts
@@ -223,9 +223,24 @@ export class WorkbenchComponent implements OnInit{
   jiraClientId!: string;
   jiraClientSecret!: string;
   jiraRedirectURL!: string;
+  jiraScopes: string[] = [
+    "manage:jira-configuration",
+    "manage:jira-project",
+    "manage:jira-webhook",
+    "read:jira-user",
+    "read:jira-work"
+  ];
+  jiraDropdownSettings: IDropdownSettings = {
+    enableCheckAll: true,
+    allowSearchFilter: true,
+    itemsShowLimit: 10,
+    closeDropDownOnSelection: false
+  };
+  selectedJiraScopes: string[] = [];
   jiraClientIdError = false;
   jiraClientSecretError = false;
   jiraRedirectURLError = false;
+  jiraScopeError = false;
   openImmybot: boolean = false;
   clientIDImmyBotError: boolean = false;
   clientIdImmybot! : string ;
@@ -935,6 +950,8 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
     this.jiraClientId = '';
     this.jiraClientSecret = '';
     this.jiraRedirectURL = '';
+    this.selectedJiraScopes = [];
+    this.jiraScopeError = false;
 
   }
   googleSheetsData = [] as any;
@@ -1892,6 +1909,16 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
     this.jiraRedirectURLError = !this.jiraRedirectURL;
   }
 
+  onJiraScopeChange(scopes?: string[] | null): void {
+    if (Array.isArray(scopes)) {
+      this.selectedJiraScopes = scopes;
+    } else if (scopes === null) {
+      this.selectedJiraScopes = [];
+    }
+
+    this.jiraScopeError = this.selectedJiraScopes.length <= 0;
+  }
+
   zohoClientIdInput(){
     this.zohoClientIdError = !this.zohoClientId;
   }
@@ -2458,11 +2485,16 @@ immybot:`<svg width="48" height="47" viewBox="0 0 24 24" aria-label="Immybot ico
     }
 
     jiraSignIn(){
+      this.onJiraScopeChange();
+      if (this.jiraScopeError) {
+        return;
+      }
       const obj = {
         "client_id": this.jiraClientId,
         "client_secret": this.jiraClientSecret,
         "redirect_uri": this.jiraRedirectURL,
         "display_name": this.displayName,
+        "scopes": this.selectedJiraScopes,
         "description": this.connectionDescription
       }
       this.workbechService.jiraConnection(obj).subscribe({next:(data)=>{
@@ -3656,6 +3688,8 @@ connectGoogleSheets(){
   this.jiraClientId = '';
   this.jiraClientSecret = '';
   this.jiraRedirectURL = '';
+  this.selectedJiraScopes = [];
+  this.jiraScopeError = false;
   this.jiraClientIdError = false;
   this.jiraClientSecretError = false;
   this.jiraRedirectURLError = false;
@@ -4482,6 +4516,8 @@ model = {
   this.selectedHubspotScopes = [];
   this.hubspotRedirectURL = '';
   this.hubspotRedirectURLError = false;
+  this.selectedJiraScopes = [];
+  this.jiraScopeError = false;
   this.zohoClientId = '';
   this.zohoClientSecret = '';
   this.zohoRedirectURL = '';


### PR DESCRIPTION
## Summary
- add Jira OAuth scope definitions, validation helpers, and payload binding for the Jira integration
- expose the scope multi-select in both Jira connection forms and document the required permissions in the UI copy
- ensure Select All updates the Jira scope validation so the Connect action becomes available when all scopes are chosen

## Testing
- npm run build *(fails: ng not found because Angular CLI dependencies are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d2ef284f208320a3f6f2fca426ebef