### PR TITLE
Preserve AI-generated chart options during layout normalization

### DIFF
--- a/src/app/components/workbench/genie-aiq-dashboard/genie-aiq-dashboard.component.ts
+++ b/src/app/components/workbench/genie-aiq-dashboard/genie-aiq-dashboard.component.ts
@@ -16,6 +16,72 @@ import { InsightEchartComponent } from '../insight-echart/insight-echart.compone
 import { InsightApexComponent } from '../insight-apex/insight-apex.component';
 import { concatMap, from, map } from 'rxjs';
 
+type LayoutChartType =
+  | 'Chart'
+  | 'Table'
+  | 'KPI';
+
+interface LayoutNumberFormat {
+  decimalPlaces: number;
+  prefix: string;
+  suffix: string;
+}
+
+interface LayoutCustomizeOptions {
+  backgroundColor: string;
+  color: string;
+  selectedColorScheme: string[];
+  isMeasureDistribution: boolean;
+  xLabelSwitch: boolean;
+  yLabelSwitch: boolean;
+  xLabelFontSize: number;
+  yLabelFontSize: number;
+  xLabelFontFamily: string;
+  yLabelFontFamily: string;
+  xlabelFontWeight: number;
+  ylabelFontWeight: number;
+  dimensionAlignment: string;
+  measureAlignment: string;
+  gridColor: string;
+  xGridSwitch: boolean;
+  yGridSwitch: boolean;
+  barCornerRadius: number;
+  dataLabels: boolean;
+  dataLabelsFontSize: number;
+  dataLabelsFontFamily: string;
+  dataLabelsColor: string;
+  isBold: boolean;
+  dataLabelsFontPosition: string;
+  legendSwitch: boolean;
+  legendsAllignment: string;
+  donutSize: number;
+  donutDecimalPlaces: number;
+}
+
+interface LayoutItem {
+  id: string;
+  x: number;
+  y: number;
+  rows: number;
+  cols: number;
+  sheetType: LayoutChartType;
+  chartType: string;
+  chartId: number;
+  isEChart: boolean;
+  data: {
+    title: string;
+    sheetTagName: string;
+  };
+  chartOptions: Record<string, any>;
+  echartOptions: Record<string, any>;
+  customizeOptions: LayoutCustomizeOptions;
+  column_Data: any[];
+  row_Data: any[];
+  chartData: any[];
+  numberFormat: LayoutNumberFormat;
+  kpiData?: Record<string, any> | null;
+}
+
 @Component({
   selector: 'app-genie-aiq-dashboard',
   standalone: true,
@@ -44,6 +110,138 @@ export class GenieAiqDashboardComponent {
   apexChartInstance!: InsightApexComponent;
   dashboardName: string = '';
   dashboardTagName: string = '';
+
+  private readonly defaultCustomizeOptions: LayoutCustomizeOptions = {
+    backgroundColor: '#ffffff',
+    color: '#2392c1',
+    selectedColorScheme: ['#1d2e92', '#088ed2'],
+    isMeasureDistribution: false,
+    xLabelSwitch: true,
+    yLabelSwitch: true,
+    xLabelFontSize: 12,
+    yLabelFontSize: 12,
+    xLabelFontFamily: 'sans-serif',
+    yLabelFontFamily: 'sans-serif',
+    xlabelFontWeight: 400,
+    ylabelFontWeight: 400,
+    dimensionAlignment: 'center',
+    measureAlignment: 'center',
+    gridColor: '#e0e0e0',
+    xGridSwitch: true,
+    yGridSwitch: true,
+    barCornerRadius: 4,
+    dataLabels: true,
+    dataLabelsFontSize: 12,
+    dataLabelsFontFamily: 'sans-serif',
+    dataLabelsColor: '#2392c1',
+    isBold: false,
+    dataLabelsFontPosition: 'top',
+    legendSwitch: true,
+    legendsAllignment: 'bottom',
+    donutSize: 70,
+    donutDecimalPlaces: 2,
+  };
+
+  private readonly defaultNumberFormat: LayoutNumberFormat = {
+    decimalPlaces: 2,
+    prefix: '',
+    suffix: '',
+  };
+
+  private coerceRecord(input: any): Record<string, any> {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+      return {};
+    }
+    try {
+      return typeof structuredClone === 'function'
+        ? structuredClone(input)
+        : JSON.parse(JSON.stringify(input));
+    } catch {
+      return { ...input };
+    }
+  }
+
+  private normalizeLayoutItems(items: any[]): LayoutItem[] {
+    if (!Array.isArray(items)) {
+      console.warn('LLM did not return an array. Falling back to empty layout.');
+      return [];
+    }
+
+    return items
+      .map((item: any, index: number) => {
+        const sanitizedId = typeof item?.id === 'string' && item.id.trim() ? item.id : this.generateLayoutId(index);
+        const x = Number.isFinite(item?.x) ? Number(item.x) : 0;
+        const y = Number.isFinite(item?.y) ? Number(item.y) : Math.floor(index / 2) * 8;
+        const rows = Number.isFinite(item?.rows) && item.rows > 0 ? Number(item.rows) : 8;
+        const cols = Number.isFinite(item?.cols) && item.cols > 0 ? Number(item.cols) : 6;
+        const sheetType = (item?.sheetType ?? 'Chart') as LayoutChartType;
+        const chartType = typeof item?.chartType === 'string' ? item.chartType : 'bar';
+        const chartId = Number.isFinite(item?.chartId) ? Number(item.chartId) : 6;
+        const chartOptions = this.coerceRecord(item?.chartOptions);
+        const echartOptions = this.coerceRecord(item?.echartOptions);
+        const isEChart =
+          typeof item?.isEChart === 'boolean'
+            ? item.isEChart
+            : Object.keys(echartOptions).length > 0;
+        const title = item?.data?.title ?? 'Untitled Chart';
+        const sheetTagName = item?.data?.sheetTagName ?? `<p>${title}</p>`;
+
+        const customizeOptions: LayoutCustomizeOptions = {
+          ...this.defaultCustomizeOptions,
+          ...(item?.customizeOptions ?? {}),
+        };
+
+        const numberFormat: LayoutNumberFormat = {
+          ...this.defaultNumberFormat,
+          ...(item?.numberFormat ?? {}),
+        };
+
+        return {
+          id: sanitizedId,
+          x,
+          y,
+          rows,
+          cols,
+          sheetType,
+          chartType,
+          chartId,
+          isEChart,
+          data: {
+            title,
+            sheetTagName,
+          },
+          chartOptions,
+          echartOptions,
+          customizeOptions,
+          column_Data: item?.column_Data ?? item?.columnData ?? [],
+          row_Data: item?.row_Data ?? item?.rowData ?? [],
+          chartData: item?.chartData ?? [],
+          numberFormat,
+          kpiData: item?.kpiData ?? null,
+        } as LayoutItem;
+      })
+      .filter((item) => !!item);
+  }
+
+  private applyDashboardLayout(layout: any[]): void {
+    const normalized = this.normalizeLayoutItems(layout);
+    if (!normalized.length) {
+      this.toasterService.warning('Could not build layout from AI response. Showing empty dashboard.');
+    }
+    this.dash1 = normalized;
+    this.showDashboardView = normalized.length > 0;
+  }
+
+  private sanitizePrompt(prompt: string): string {
+    return prompt.replace(/\s+/g, ' ').trim();
+  }
+
+  private generateLayoutId(index: number): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `chart-${Date.now()}-${index}`;
+  }
 
     @ViewChild('sheetcontainer', { read: ViewContainerRef }) container!: ViewContainerRef;
  chatHistory: ChatMessage[] = [];
@@ -122,7 +320,7 @@ onServerTypeSelect(type: string) {
     }
 })
   }
-  onTableSelect() {
+  onTableSelect(promptOverride?: string) {
     if (this.selectedTables && this.selectedTables.length > 0) {
       // Get schema names for selected tables
       // const selectedTableObjects = this.schematableList.filter((tbl: any) => this.selectedTables.includes(tbl.table));
@@ -151,10 +349,11 @@ onServerTypeSelect(type: string) {
       // }
        const selectedTableNames = this.selectedTables.slice();
     console.log('Selected table names:', selectedTableNames);
+      const sanitizedPrompt = this.sanitizePrompt(promptOverride ?? this.userPrompt ?? '');
       const Obj= {
          "hierarchy_id":this.hierarchyId,
          "table_name":selectedTableNames,
-         "prompt": this.userPrompt ? this.userPrompt : null,
+         "prompt": sanitizedPrompt || null,
         }
       this.workbechService.getChartSuggestions(Obj).subscribe({
       next:(data)=>{
@@ -236,15 +435,15 @@ isInsightSelected(insight: any): boolean {
   }
   userPrompt: string = '';
 
-sendPrompt() {
+  sendPrompt() {
   if (!this.userPrompt || !this.userPrompt.trim()) {
     this.toasterService.error('Please enter a prompt', 'Error');
     return;
   }
-  console.log('User prompt:', this.userPrompt);
-  // Call your API or handle the message sending logic here
-  this.userPrompt = ''; // Clear input after sending
-  this.onTableSelect();
+  const sanitizedPrompt = this.sanitizePrompt(this.userPrompt);
+  console.log('User prompt:', sanitizedPrompt);
+  this.onTableSelect(sanitizedPrompt);
+  this.userPrompt = '';
 }
 
 
@@ -279,9 +478,14 @@ isCreateDisabled(): boolean {
 showDashboardView = false;
 dash1: any = [];
 promptDashboard(){
+  const sanitizedPrompt = this.sanitizePrompt(this.userPrompt ?? '');
+  if (!sanitizedPrompt) {
+    this.toasterService.error('Please enter a prompt', 'Error');
+    return;
+  }
   const payload ={
     h_id: this.hierarchyId,
-    question:this.userPrompt
+    question: sanitizedPrompt
   }
     this.workbechService.promptDashboard(payload).subscribe({
       next:(data)=>{
@@ -548,8 +752,7 @@ promptDashboard(){
             console.log("Chart Options:", chartOptions);
 
             // Assign result
-            this.dash1 = chartOptions;
-            this.showDashboardView = true;
+            this.applyDashboardLayout(chartOptions);
             this.loaderService.hide();
           })
           .catch(err => {
@@ -566,13 +769,16 @@ promptDashboard(){
 customizeDashboard(){
   const data = this.dash1;
   this.loaderService.show();
-  this.openAi.getChartOptions(data, this.userPrompt + "/n" + "do not remove any other charts, do update only relative chart only")
+  const sanitizedPrompt = this.sanitizePrompt(this.userPrompt ?? '');
+  const enrichedPrompt = sanitizedPrompt
+    ? `${sanitizedPrompt}. Do not remove unrelated charts; only update the charts that match the request.`
+    : 'Do not remove unrelated charts; only update the charts that match the request.';
+  this.openAi.getChartOptions(data, enrichedPrompt)
   .then(chartOptions => {
     console.log("Chart Options:", chartOptions);
 
     // Assign result
-    this.dash1 = chartOptions;
-    // this.showDashboardView = true;
+    this.applyDashboardLayout(chartOptions);
     this.loaderService.hide();
   })
   .catch(err => {
@@ -581,12 +787,12 @@ customizeDashboard(){
   });
 
 
-   if (!this.userPrompt.trim()) return;
-    const currentPrompt = this.userPrompt; 
+   if (!sanitizedPrompt) return;
+    const currentPrompt = sanitizedPrompt;
     // Push user message
     this.chatHistory.push({
       sender: 'User',
-      text: this.userPrompt,
+      text: sanitizedPrompt,
       timestamp: new Date()
     });
 

--- a/src/app/services/openai.service.ts
+++ b/src/app/services/openai.service.ts
@@ -1,6 +1,30 @@
 import { Injectable } from '@angular/core';
 import OpenAI from 'openai';
 
+interface SheetPayload {
+  id: string;
+  x: number;
+  y: number;
+  rows: number;
+  cols: number;
+  sheetType: string;
+  chartType: string;
+  chartId?: number;
+  isEChart: boolean;
+  data?: {
+    title?: string;
+    sheetTagName?: string;
+  };
+  chartOptions?: Record<string, any>;
+  echartOptions?: Record<string, any>;
+  customizeOptions?: Record<string, any>;
+  column_Data?: any[];
+  row_Data?: any[];
+  chartData?: any[];
+  numberFormat?: Record<string, any>;
+  kpiData?: Record<string, any> | null;
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -13,319 +37,197 @@ export class OpenaiService {
     dangerouslyAllowBrowser: true,  // Only for testing
   });
 
+  private readonly defaultCustomizeOptions = {
+    backgroundColor: '#ffffff',
+    color: '#2392c1',
+    selectedColorScheme: ['#1d2e92', '#088ed2'],
+    isMeasureDistribution: false,
+    xLabelSwitch: true,
+    yLabelSwitch: true,
+    xLabelFontSize: 12,
+    yLabelFontSize: 12,
+    xLabelFontFamily: 'sans-serif',
+    yLabelFontFamily: 'sans-serif',
+    xlabelFontWeight: 400,
+    ylabelFontWeight: 400,
+    dimensionAlignment: 'center',
+    measureAlignment: 'center',
+    gridColor: '#e0e0e0',
+    xGridSwitch: true,
+    yGridSwitch: true,
+    barCornerRadius: 4,
+    dataLabels: true,
+    dataLabelsFontSize: 12,
+    dataLabelsFontFamily: 'sans-serif',
+    dataLabelsColor: '#2392c1',
+    isBold: false,
+    dataLabelsFontPosition: 'top',
+    legendSwitch: true,
+    legendsAllignment: 'bottom',
+    donutSize: 70,
+    donutDecimalPlaces: 2,
+  };
+
+  private layoutCache = new Map<string, any>();
+
+  private readonly chartTypeToId: Record<string, number> = {
+    table: 1,
+    hstacked: 2,
+    'horizontal stacked': 2,
+    hgrouped: 3,
+    'bar-line': 4,
+    'stacked-bar': 5,
+    bar: 6,
+    'side-bar': 7,
+    'multi-line': 8,
+    pivot: 9,
+    donut: 10,
+    calendar: 11,
+    radar: 12,
+    line: 13,
+    area: 17,
+    pie: 24,
+    kpi: 25,
+    'heat map': 26,
+    funnel: 27,
+    gauge: 28,
+    map: 29,
+    'world map': 29,
+  };
+
   async getChartOptions(data: any, userPrompt?: any): Promise<any> {
+    const sheets = this.buildSheetPayload(data);
+    const prompt = typeof userPrompt === 'string' ? userPrompt.trim() : '';
+    const cacheKey = this.buildCacheKey(sheets, prompt);
+
+    if (this.layoutCache.has(cacheKey)) {
+      return this.clone(this.layoutCache.get(cacheKey));
+    }
+
     const response = await this.openai.chat.completions.create({
-      model: 'gpt-4o-mini', // or gpt-4.1-mini
+      model: 'gpt-4o-mini',
+      temperature: 0.2,
       messages: [
         {
-          role: "system",
-          content: `You are a chart generator for an Angular dashboard using Gridster. 
-Convert the given data into a valid array of chart objects.
-
-# **Rules:**
-1. Always return a **JSON array** where each element is one chart object.  
-2. **Each chart object must include:**  
-   **- id (Gridster item ID)  
-   - chartId (must follow the mapping below)  
-   - x, y, rows, cols (for Gridster position/size)  
-   - sheetType (must be "Chart" unless user specifies Table)  
-   - chartType (must be chart type as, e.g. "bar", "line", "pie", etc. except KPI and Table it should be "KPI" and "Table")  
-   - chartOptions (for ApexCharts, must always include "series")  
-   - echartOptions (for ECharts, must always include "series")  
-   - isEChart: true if using ECharts, false if using ApexCharts  
-   - chartData, column_Data, row_Data, numberFormat, customizeOptions (when provided)  
-   - kpiData (if chartType is KPI, must include kpiNumber, kpiPrefix, kpiSuffix, kpiDecimalPlaces, rows, fontSize, color, trendData, trendLabels, kpiShowTrendline, showKpiIndicator, indicatorIsIncreased, indicatorValue, kpiTarget) and KPI's position in gridster must be at top if more than one KPI they should align one after the other with square shaped gridster item
-   - customizeOptions (must always be included with defaults, and applied to chartOptions/echartOptions if used)  
-   - do not include customizeOptions inside chartOptions or echartOptions; it must be a separate key
-   - if isEChart = true → chart configuration must only be inside echartOptions and empty object for chartOptions. If isEChart = false → chart configuration must only be inside chartOptions and empty object for echartOptions.
-   - if isEChart = true → customization values must be taken from echartOptions. If isEChart = false → customization values must be taken from chartOptions. In both cases, update customizeOptions with the same values.
-   - from user-given data, **columns are used for x-axis categories (or labels for pie/donut in ApexCharts)**, and **rows are used as series in chartOptions/echartOptions**. 
-   - data object must include title and sheetTagName, which are initialized from the user-provided sheet_name.**
-
-3. **ChartId Mapping (must be strictly followed):**  
-   - "Table Chart" → 1  
-   - "HStacked Chart" → 2  
-   - "HGrouped Chart" → 3  
-   - "Bar-Line Chart" → 4  
-   - "Stacked-Bar Chart" → 5  
-   - "Bar Chart" → 6  
-   - "Side-Bar Chart" → 7  
-   - "Multi-Line Chart" → 8  
-   - "Pivot Table" → 9  
-   - "Donut Chart" → 10  
-   - "Calendar Chart" → 11  
-   - "Radar Chart" → 12  
-   - "Line Chart" → 13  
-   - "Area Chart" → 17  
-   - "Pie Chart" → 24  
-   - "KPI Chart" → 25  
-   - "Heat Map" → 26  
-   - "Funnel Chart" → 27  
-   - "Gauge Chart" → 28  
-   - "World Map" → 29  
-
-4. **If "library = echart", populate the chart configuration in "echartOptions" and set "isEChart: true".  
-   If "library = apex", populate the chart configuration in "chartOptions" and set "isEChart: false".**  
-
-5. **If isEChart = true → chart configuration must only be inside echartOptions.  
-   If isEChart = false → chart configuration must only be inside chartOptions.** 
-
-6. Always produce JSON that is **valid for Angular ApexCharts or Angular ECharts plugins**.  
-
-7. Use the given data (columns, rows, chartType, library, etc.) to build the chart options.  
-   - Infer xAxis, yAxis, categories, series, labels, colors, and legends.  
-   - Respect formatting options like decimal places, prefixes, suffixes.  
-   - Apply **customizeOptions** into the correct chartOptions/echartOptions keys.  
-
-8. **If any customization is changed in chartOptions/echartOptions (e.g., backgroundColor, fontSize, legends, dataLabels, etc.), then the same value must also be updated inside customizeOptions.**  
-
-9. **If isEChart = true → always read customization values from echartOptions and update customizeOptions.  
-  If isEChart = false → always read customization values from chartOptions and update customizeOptions.**  
-
-10. **If isEChart = true → update echartOptions if any customizations changes.
-  If isEChart = false → update chartOptions if any customizations changes.**
-
-11. Ensure all chart options strictly follow either ApexCharts or ECharts schemas.  
-
-12. Multiple charts must be returned if user asks for more than one.  
-
-13. Gridster notes:  
-   - x, y, rows, cols define item layout.  
-   - sheetType = "Chart" except Table.  
-   - Compatible with Bootstrap 5 responsive grid system.  
-
-14. Map data.title and data.sheetTagName with "sheet_name" from data
-
-15. Return **only raw JSON array** as the final answer. No markdown, no explanations.    
-
----
-
-#** Default customizeOptions (must always be included):**
-
-{
-  "backgroundColor": "#ffffff",
-  "color": "#2392c1",
-  "selectedColorScheme": ["#1d2e92", "#088ed2"],
-  "isMeasureDistribution": false,
-  "xLabelSwitch": true,
-  "yLabelSwitch": true,
-  "xLabelFontSize": 12,
-  "yLabelFontSize": 12,
-  "xLabelFontFamily": "sans-serif",
-  "yLabelFontFamily": "sans-serif",
-  "xlabelFontWeight": 400,
-  "ylabelFontWeight": 400,
-  "dimensionAlignment": "center",
-  "measureAlignment": "center",
-  "gridColor": "#e0e0e0",
-  "xGridSwitch": true,
-  "yGridSwitch": true,
-  "barCornerRadius": 4,
-  "dataLabels": true,
-  "dataLabelsFontSize": 12,
-  "dataLabelsFontFamily": "sans-serif",
-  "dataLabelsColor": "#2392c1",
-  "isBold": false,
-  "dataLabelsFontPosition": "top",
-  "legendSwitch": true,
-  "legendsAllignment": "bottom",
-  "donutSize": 70,
-  "donutDecimalPlaces": 2
-}
-
----
-
-#** 🔗 CustomizeOptions → Chart Mapping:**
-
-- backgroundColor → Apex: chart.background | ECharts: backgroundColor  
-- selectedColorScheme / color → Apex: colors | ECharts: color  
-- isMeasureDistribution → Apex: plotOptions.bar.distributed or setColorsOnRanges() | ECharts: colorBy: 'data' with setColorsOnRanges()  
-- xLabelSwitch → Apex: xaxis.labels.show | ECharts: xAxis.axisLabel.show  
-- yLabelSwitch → Apex: yaxis.labels.show | ECharts: yAxis.axisLabel.show  
-- xLabelFontSize → Apex: xaxis.labels.style.fontSize | ECharts: xAxis.axisLabel.fontSize  
-- yLabelFontSize → Apex: yaxis.labels.style.fontSize | ECharts: yAxis.axisLabel.fontSize  
-- xLabelFontFamily → Apex: xaxis.labels.style.fontFamily | ECharts: xAxis.axisLabel.fontFamily  
-- yLabelFontFamily → Apex: yaxis.labels.style.fontFamily | ECharts: yAxis.axisLabel.fontFamily  
-- xlabelFontWeight → Apex: xaxis.labels.style.fontWeight | ECharts: xAxis.axisLabel.fontWeight  
-- ylabelFontWeight → Apex: yaxis.labels.style.fontWeight | ECharts: yAxis.axisLabel.fontWeight  
-- dimensionAlignment → Apex: xaxis.labels.offsetX | ECharts: xAxis.axisLabel.align  
-- measureAlignment → Apex: yaxis.labels.offsetY | ECharts: yAxis.axisLabel.align  
-- gridColor → Apex: grid.borderColor | ECharts: xAxis.splitLine.lineStyle.color, yAxis.splitLine.lineStyle.color  
-- xGridSwitch → Apex: grid.xaxis.lines.show | ECharts: xAxis.splitLine.show  
-- yGridSwitch → Apex: grid.yaxis.lines.show | ECharts: yAxis.splitLine.show  
-- barCornerRadius → Apex: plotOptions.bar.borderRadius | ECharts: series.itemStyle.borderRadius  
-- dataLabelsFontSize → Apex: dataLabels.style.fontSize | ECharts: series.label.fontSize  
-- dataLabelsFontFamily → Apex: dataLabels.style.fontFamily | ECharts: series.label.fontFamily  
-- dataLabelsColor → Apex: dataLabels.style.colors | ECharts: series.label.color  
-- isBold → Apex: dataLabels.style.fontWeight | ECharts: series.label.fontWeight  
-- dataLabelsFontPosition → Apex: plotOptions.bar.dataLabels.position | ECharts: series.label.position  
-- legendSwitch → Apex: legend.show | ECharts: legend.show  
-- legendsAllignment → Apex: legend.position | ECharts: legend.left / legend.orient  
-- donutSize → Apex: plotOptions.pie.donut.size | ECharts: series.radius  
-- donutDecimalPlaces → Apex: plotOptions.pie.donut.labels.total.formatter | ECharts: series.label.formatter  
-
----
-
-#** Reference Output JSON:**
-
-[
-  {
-
-"id": "6447d5e4-bbc9-4b3b-99c5-6971978fad4e",
-  "x": 14,
-  "y": 5,
-  "rows": 8,
-  "cols": 9,
-    "data": {
-        "title": "Total Customers",
-        "sheetTagName": "<p>Total Customers</p>"
-    },
-  "sheetType": "Chart",
-  "chartType": "bar",
-  "chartId": 6,
-  "isEChart": true,
-   "kpiData": {
-        "kpiNumber": "29.00",
-        "kpiPrefix": "",
-        "kpiSuffix": "",
-        "kpiDecimalUnit": "none",
-        "kpiDecimalPlaces": 2,
-        "rows": [
-            {
-                "col": "CNTD(Id)",
-                "result_data": [
-                    29
-                ]
-            }
-        ],
-        "fontSize": 4,
-        "color": "#ba68c8",
-        "kpiChartColor": "#2392c1",
-        "trendData": [
-            7,
-            16,
-            10
-        ],
-        "trendLabels": [
-            "2024-01-01",
-            "2025-01-01",
-            "null"
-        ],
-        "kpiShowTrendline": true,
-        "showKpiIndicator": true,
-        "indicatorIsIncreased": "up",
-        "indicatorValue": 45,
-        "kpiTarget": 20
-    },
-  "echartOptions": {
-    "backgroundColor": "#fff",
-    "legend": { "orient": "vertical", "left": "left" },
-    "tooltip": { "trigger": "axis" },
-    "axisPointer": { "type": "none" },
-    "grid": { "left": "3%", "right": "4%", "bottom": "13%", "containLabel": true },
-    "xAxis": {
-      "type": "category",
-      "data": ["Category 1", "Category 2"],
-      "axisLine": { "lineStyle": { "color": "#2392c1" } },
-      "axisLabel": { "show": true, "fontSize": 12, "color": "#2392c1" }
-    },
-    "yAxis": { "type": "value" },
-    "series": [
-      { "type": "bar", "barWidth": "80%", "data": [100, 200] }
-    ],
-    "color": ["#1d2e92", "#088ed2"]
-  },
-  "chartOptions": {
-    "series": [
-      { "name": "Series 1", "data": [100, 200], "group": "apexcharts-axis-0" }
-    ],
-    "chart": { "type": "bar", "height": 320, "background": "#fff" },
-    "xaxis": {
-      "categories": ["Category 1", "Category 2"],
-      "labels": { "style": { "fontSize": 12, "fontFamily": "sans-serif" } }
-    },
-    "yaxis": {
-      "labels": { "style": { "fontSize": 12, "fontFamily": "sans-serif" } }
-    },
-    "plotOptions": {
-      "bar": { "distributed": true, "dataLabels": { "position": "top" } }
-    },
-    "dataLabels": {
-      "enabled": true,
-      "style": { "fontSize": "12px", "fontFamily": "sans-serif", "colors": ["#2392c1"] }
-    },
-    "colors": ["#1d2e92", "#088ed2"]
-  },
-
-  "chartData": [],
-  "column_Data": [],
-  "row_Data": [],
-  "numberFormat": {
-    "decimalPlaces": 2,
-    "prefix": "",
-    "suffix": ""
-  },
-    "customizeOptions": {
-      "backgroundColor": "#ffffff",
-      "color": "#2392c1",
-      "selectedColorScheme": ["#1d2e92", "#088ed2"],
-      "isMeasureDistribution": false,
-      "xLabelSwitch": true,
-      "yLabelSwitch": true,
-      "xLabelFontSize": 12,
-      "yLabelFontSize": 12,
-      "xLabelFontFamily": "sans-serif",
-      "yLabelFontFamily": "sans-serif",
-      "xlabelFontWeight": 400,
-      "ylabelFontWeight": 400,
-      "dimensionAlignment": "center",
-      "measureAlignment": "center",
-      "gridColor": "#e0e0e0",
-      "xGridSwitch": true,
-      "yGridSwitch": true,
-      "barCornerRadius": 4,
-      "dataLabels": true,
-      "dataLabelsFontSize": 12,
-      "dataLabelsFontFamily": "sans-serif",
-      "dataLabelsColor": "#2392c1",
-      "isBold": false,
-      "dataLabelsFontPosition": "top",
-      "legendSwitch": true,
-      "legendsAllignment": "bottom",
-      "donutSize": 70,
-      "donutDecimalPlaces": 2
-    }
-  }
-]`
+          role: 'system',
+          content: this.buildSystemPrompt(),
         },
         {
-          role: "user",
-          content: `
-Data: ${JSON.stringify(data)},
-Prompt: ${JSON.stringify(userPrompt)}
-`
-        }
-      ]
+          role: 'user',
+          content: JSON.stringify({
+            sheets,
+            prompt,
+          }),
+        },
+      ],
     });
-    
-    // console.log(JSON.parse(response.choices[0].message.content ?? ''));
-    // const chartOptions = JSON.parse(response.choices[0].message?.content || '{}');
-    // return chartOptions;
 
-    // Get raw content
-  let content = response.choices[0].message?.content || '';
+    const content = this.extractContent(response);
 
-  // 🧹 Clean out ```json or ``` wrappers
-  content = content.replace(/```json|```/g, '').trim();
-  content = content.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
-
-  try {
-    const chartOptions = JSON.parse(content);
-    console.log("✅ Parsed Chart Options:", chartOptions);
-    return chartOptions;
-  } catch (err) {
-    console.error("❌ Failed to parse chart options", err, content);
-    throw err;
+    try {
+      const layout = JSON.parse(content);
+      const hydrated = this.hydrateLayout(layout);
+      this.layoutCache.set(cacheKey, hydrated);
+      return this.clone(hydrated);
+    } catch (err) {
+      console.error('❌ Failed to parse chart options', err, content);
+      throw err;
+    }
   }
+
+  private buildSheetPayload(data: any): SheetPayload[] {
+    const sheets: any[] = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.sheets)
+      ? data.sheets
+      : [];
+
+    return sheets.map((sheet: any, index: number) => {
+      const id = typeof sheet?.id === 'string' && sheet.id ? sheet.id : `sheet-${index}`;
+      const chartType = sheet?.chartType ?? sheet?.chart_type ?? 'bar';
+      const chartId = sheet?.chartId ?? sheet?.chart_id ?? this.chartTypeToId[String(chartType).toLowerCase()];
+      const isEChart = sheet?.isEChart ?? sheet?.library === 'echart';
+      const grid = {
+        x: Number.isFinite(sheet?.x) ? Number(sheet.x) : 0,
+        y: Number.isFinite(sheet?.y) ? Number(sheet.y) : Math.floor(index / 2) * 8,
+        rows: Number.isFinite(sheet?.rows) ? Number(sheet.rows) : sheet?.h ?? 8,
+        cols: Number.isFinite(sheet?.cols) ? Number(sheet.cols) : sheet?.w ?? 6,
+      };
+
+      return {
+        id,
+        x: grid.x,
+        y: grid.y,
+        rows: grid.rows,
+        cols: grid.cols,
+        sheetType: sheet?.sheetType ?? 'Chart',
+        chartType,
+        chartId,
+        isEChart: Boolean(isEChart),
+        data: sheet?.data ?? {
+          title: sheet?.sheet_name ?? 'Untitled Chart',
+          sheetTagName: sheet?.data?.sheetTagName ?? `<p>${sheet?.sheet_name ?? 'Untitled Chart'}</p>`,
+        },
+        chartOptions: sheet?.chartOptions ?? {},
+        echartOptions: sheet?.echartOptions ?? {},
+        customizeOptions: sheet?.customizeOptions ?? this.defaultCustomizeOptions,
+        column_Data: sheet?.column_Data ?? sheet?.columns ?? [],
+        row_Data: sheet?.row_Data ?? sheet?.rows ?? [],
+        chartData: sheet?.chartData ?? [],
+        numberFormat: sheet?.numberFormat ?? {
+          decimalPlaces: 2,
+          prefix: '',
+          suffix: '',
+        },
+        kpiData: sheet?.kpiData ?? null,
+      } satisfies SheetPayload;
+    });
+  }
+
+  private hydrateLayout(layout: any): any[] {
+    if (!Array.isArray(layout)) {
+      throw new Error('LLM response must be an array');
+    }
+
+    return layout.map((item: any) => ({
+      ...item,
+      customizeOptions: {
+        ...this.defaultCustomizeOptions,
+        ...(item?.customizeOptions ?? {}),
+      },
+    }));
+  }
+
+  private buildCacheKey(sheets: SheetPayload[], prompt: string): string {
+    return JSON.stringify({ sheets, prompt });
+  }
+
+  private buildSystemPrompt(): string {
+    return `You convert sheet metadata into a Gridster layout JSON array for an Angular dashboard.
+Requirements:
+- Always respond with a raw JSON array (no Markdown).
+- Each item must include: id, x, y, rows, cols, sheetType, chartType, chartId, isEChart, chartOptions, echartOptions, data, chartData, column_Data, row_Data, numberFormat, customizeOptions, kpiData (when applicable).
+- Respect existing ids and grid positions when provided.
+- Keep KPI tiles square and aligned at the top rows when multiple KPIs exist.
+- If isEChart=true use echartOptions only; if false use chartOptions only.
+- When prompt asks for updates, modify only relevant charts.
+- Always supply customizeOptions and numberFormat. Use provided defaults when values are missing.
+- Apply chart instructions such as "2 charts per row" or "change bar to pie" using the Gridster coordinates.
+- Use chartId mapping already supplied in the payload. If missing, infer based on chartType.
+- Ensure JSON is syntactically valid.`;
+  }
+
+  private extractContent(response: OpenAI.Chat.Completions.ChatCompletion): string {
+    let content = response.choices[0].message?.content || '';
+    content = content.replace(/```json|```/g, '').trim();
+    content = content.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    return content;
+  }
+
+  private clone<T>(value: T): T {
+    if (typeof structuredClone === 'function') {
+      return structuredClone(value);
+    }
+    return JSON.parse(JSON.stringify(value));
   }
 }


### PR DESCRIPTION
## Summary
- add a defensive coerceRecord helper so AI layout responses retain complete chart and echart option payloads
- infer isEChart from returned options and avoid clearing chartOptions, ensuring normalization produces the reference JSON structure

## Testing
- npm run build *(fails: ng command not found in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d4f239e99c8320a2982b9c7ea0d0f2