### PR TITLE
fix: harden asset delivery and block forced install route

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -28,6 +28,7 @@
             ],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
+            "deployUrl": "/",
             "assets": [
               "src/favicon.ico",
               "src/assets",

--- a/nginx.conf
+++ b/nginx.conf
@@ -28,6 +28,15 @@ http {
         listen 80;
         server_name InsightApps;
 
+        add_header X-Frame-Options "DENY" always;
+        add_header X-Content-Type-Options "nosniff" always;
+        add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+        # Block access to non-existent setup utilities discovered by scanners
+        location ~* ^/authentication/install/?$ {
+            return 404;
+        }
+
         location / {
             # root   /usr/share/nginx/html/InsightApps-Angular;
             # root /InsightApps-Angular/src/index.html;

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="author">
   <meta name="keywords" content="front end framework,admin panel,angular template, dashboard,admin dashboard,admin,angular,admin template,angular dashboard,admin panel template,angular framework,template dashboard,ng bootstrap, bootstrap ng,">
-  <link rel="icon" type="image/x-icon" href="./assets/images/brand/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="/assets/images/brand/favicon.ico">
   <link
   rel="stylesheet"
   href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"


### PR DESCRIPTION
## Summary
- add a deploy URL so Angular builds emit absolute asset links and avoid PRSSI findings
- deliver the favicon from an absolute path to align with absolute asset loading
- send common hardening headers and explicitly return 404 for the forced-browsing install path in nginx

## Testing
- `npm install` *(fails: dependency conflict between @angular/common@17 and angular-gridster2@18)*

------
https://chatgpt.com/codex/tasks/task_b_68e2ac1eb7a483209a6563b01f2a610f