### PR TITLE
Add KPI layout and title positioning controls

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1236,7 +1236,7 @@
                   <button class="btn btn-primary " style="margin-right: 10px;" (click)="setDrillThrough('',item)"><i
                       class="fa fa-undo "></i> </button>
                   }
-                  @if(item['type'] !== 'image'){
+                  @if(item['type'] !== 'image' && !(item['chartType'] === 'KPI' && item['chartId'] === 25)){
                   <div style="width: 100%;"
                     [innerHtml]="sheetTagTitle[item.data?.title]?sheetTagTitle[item.data?.title]:item.data?.sheetTagName"></div>
                   }
@@ -1325,6 +1325,12 @@
                         <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25 && item['kpiImage']"
                           [classesList]="'dropdown-item'" [buttonName]="'Remove Image'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="removeKpiImage(item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit Layout'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openLayoutModal(layoutModal, item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit Title'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openTitleModal(titleModal, item)" [isIcon]="false"></app-insights-button>
                           <app-insights-button 
                             *ngIf="!isPublicUrl && item['type'] === 'text' && !item['textImage']" 
                             [classesList]="'dropdown-item'" 
@@ -1621,36 +1627,47 @@
                 }
                 <div *ngIf="['Table', 'KPI', 'PIVOT'].includes(item['chartType'])" class="card-body p-1">
                   @if(item['chartType'] === 'KPI' && item['chartId']=== 25){
-                  <div (click)="setDrillThrough('',item,true)" class="big-number-container" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                  <div (click)="setDrillThrough('',item,true)" class="big-number-container position-relative" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                    <div *ngIf="item['type'] !== 'image'"
+                      class="position-absolute"
+                      [ngStyle]="getPositionStyles(item['kpiData']?.kpiTitlePosition, 'top-left')"
+                      style="width: max-content; max-width: 90%;">
+                      <div [innerHtml]="sheetTagTitle[item.data?.title] ? sheetTagTitle[item.data?.title] : item.data?.sheetTagName"></div>
+                    </div>
+                    <div class="position-absolute"
+                      [ngStyle]="getPositionStyles(item['kpiData']?.kpiNumberPosition, 'middle-center')">
+                      <h1 *ngIf="item['kpiData']?.kpiNumber !== undefined" class="big-number" [style.font-size]="item['kpiData']?.fontSize + 'rem'"
+                        [style.color]="item['kpiData']?.color">{{ item['kpiData']?.kpiNumber }}</h1>
+                    </div>
                     @for(row of item['kpiData'].rows;track row){
-                    <h1 *ngIf="row?.result_data" class="big-number" [style.font-size]="item['kpiData']?.fontSize+'rem'"
-                      [style.color]="item['kpiData']?.color">{{ item['kpiData']?.kpiNumber }}</h1>
-                       <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted" [style.color]="item['kpiData']?.color" style="font-size: 13px;">
-                              Target: {{ item['kpiData']?.kpiTarget }}
+                    <ng-container *ngIf="row?.result_data">
+                      <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted" [style.color]="item['kpiData']?.color" style="font-size: 13px;">
+                        Target: {{ item['kpiData']?.kpiTarget }}
+                      </div>
+                      <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
+                          [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
+                          [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
+                          [stroke]="{ curve: 'smooth', width: 2 }"
+                          [colors]="[item['kpiData']?.kpiChartColor]"
+                          [tooltip]="{ enabled: true }"
+                          [xaxis]="{ categories: item['kpiData']?.trendLabels}"
+                          style="margin-top: 5px;">
+                        </apx-chart>
+                        <div *ngIf="item['kpiData']?.showKpiIndicator"
+                            class="d-flex justify-content-around mt-2 flex-wrap text-center"
+                            style="font-size: 12px;">
+                          <span [ngStyle]="{
+                                  color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
+                                  fontWeight: 'bold'
+                                }">
+                            <i class="bi"
+                              [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
+                                              ? 'bi-arrow-up'
+                                              : 'bi-arrow-down'"></i>
+                            {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
+                          </span>
                         </div>
-                        <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
-                            [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
-                            [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
-                            [stroke]="{ curve: 'smooth', width: 2 }"
-                            [colors]="[item['kpiData']?.kpiChartColor]"
-                            [tooltip]="{ enabled: true }"
-                            [xaxis]="{ categories: item['kpiData']?.trendLabels}"
-                            style="margin-top: 5px;">
-                          </apx-chart>
-                            <div *ngIf="item['kpiData']?.showKpiIndicator"
-                                class="d-flex justify-content-around mt-2 flex-wrap text-center"
-                                style="font-size: 12px;">
-                              <span [ngStyle]="{
-                                      color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
-                                      fontWeight: 'bold'
-                                    }">
-                                <i class="bi"
-                                  [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
-                                                ? 'bi-arrow-up'
-                                                : 'bi-arrow-down'"></i>
-                                {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
-                              </span>
-                            </div>
+                    </ng-container>
                     }
                     <i [class]="item['kpiIconsArray']?.kpiIcon" [style.font-size]="item['kpiIconsArray']?.kpiIconSize + 'px'"
                       [style.color]="item['kpiIconsArray']?.kpiIconColor"
@@ -1903,6 +1920,12 @@
                         <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25 && item['kpiImage']"
                           [classesList]="'dropdown-item'" [buttonName]="'Remove Image'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="removeKpiImage(item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit Layout'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openLayoutModal(layoutModal, item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit Title'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openTitleModal(titleModal, item)" [isIcon]="false"></app-insights-button>
                         <input type="file" #ImageUploadKPI (change)="imageFileSelectEvent($event)" accept="image/*"
                           style="display: none;" />
                       </div>
@@ -2156,41 +2179,52 @@
                 }
                 <div *ngIf="['Table', 'KPI', 'PIVOT'].includes(item['chartType'])" class="card-body p-1">
                   @if(item['chartType'] === 'KPI' && item['chartId']=== 25){
-                  <div (click)="setDrillThrough('',item,true)" class="big-number-container" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                  <div (click)="setDrillThrough('',item,true)" class="big-number-container position-relative" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
+                    <div *ngIf="item['type'] !== 'image'"
+                      class="position-absolute"
+                      [ngStyle]="getPositionStyles(item['kpiData']?.kpiTitlePosition, 'top-left')"
+                      style="width: max-content; max-width: 90%;">
+                      <div [innerHtml]="sheetTagTitle[item.data?.title] ? sheetTagTitle[item.data?.title] : item.data?.sheetTagName"></div>
+                    </div>
+                    <div class="position-absolute"
+                      [ngStyle]="getPositionStyles(item['kpiData']?.kpiNumberPosition, 'middle-center')">
+                      <h1 *ngIf="item['kpiData']?.kpiNumber !== undefined" class="big-number" [style.font-size]="item['kpiData']?.fontSize + 'rem'"
+                        [style.color]="item['kpiData']?.color">{{ item['kpiData']?.kpiNumber }}</h1>
+                    </div>
                     @for(row of item['kpiData'].rows;track row){
-                    <h1 *ngIf="row?.result_data" class="big-number" [style.font-size]="item['kpiData']?.fontSize+'rem'"
-                      [style.color]="item['kpiData']?.color">{{ item['kpiData']?.kpiNumber }}</h1>
-                       <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted" [style.color]="item['kpiData']?.color" style="font-size: 13px;">
-                              Target: {{ item['kpiData']?.kpiTarget }}
+                    <ng-container *ngIf="row?.result_data">
+                      <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted" [style.color]="item['kpiData']?.color" style="font-size: 13px;">
+                        Target: {{ item['kpiData']?.kpiTarget }}
+                      </div>
+                      <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
+                          [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
+                          [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
+                          [stroke]="{ curve: 'smooth', width: 2 }"
+                          [colors]="[item['kpiData']?.kpiChartColor]"
+                          [tooltip]="{ enabled: true }"
+                          [xaxis]="{ categories: item['kpiData']?.trendLabels}"
+                          style="margin-top: 5px;">
+                        </apx-chart>
+                        <div *ngIf="item['kpiData']?.showKpiIndicator"
+                            class="d-flex justify-content-around mt-2 flex-wrap text-center"
+                            style="font-size: 12px;">
+                          <span [ngStyle]="{
+                                  color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
+                                  fontWeight: 'bold'
+                                }">
+                            <i class="bi"
+                              [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
+                                              ? 'bi-arrow-up'
+                                              : 'bi-arrow-down'"></i>
+                            {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
+                          </span>
                         </div>
-                        <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
-                            [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
-                            [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
-                            [stroke]="{ curve: 'smooth', width: 2 }"
-                            [colors]="[item['kpiData']?.kpiChartColor]"
-                            [tooltip]="{ enabled: true }"
-                            [xaxis]="{ categories: item['kpiData']?.trendLabels}"
-                            style="margin-top: 5px;">
-                          </apx-chart>
-                            <div *ngIf="item['kpiData']?.showKpiIndicator"
-                                class="d-flex justify-content-around mt-2 flex-wrap text-center"
-                                style="font-size: 12px;">
-                              <span [ngStyle]="{
-                                      color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
-                                      fontWeight: 'bold'
-                                    }">
-                                <i class="bi"
-                                  [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
-                                                ? 'bi-arrow-up'
-                                                : 'bi-arrow-down'"></i>
-                                {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
-                              </span>
-                            </div>
+                    </ng-container>
                     }
                     <i [class]="item['kpiIconsArray']?.kpiIcon" [style.font-size]="item['kpiIconsArray']?.kpiIconSize + 'px'"
                       [style.color]="item['kpiIconsArray']?.kpiIconColor"
                       [ngStyle]="getIconPositionStyles(item['kpiIconsArray']?.kpiIconPosition)" style="position: absolute;"></i>
-                  </div>
+                </div>
                   }
                   <!-- <div *ngIf="item['chartType'] === 'Table'"> -->
                     <div *ngIf="item['chartType'] === 'Table'" class="table-responsive" [ngClass]="{ 'hidden-overflow': isOverflowHidden, 'overflow-auto': !isOverflowHidden }">
@@ -2324,6 +2358,39 @@
 
 
 
+
+  <ng-template #layoutModal let-modal>
+    <ng-container *ngTemplateOutlet="positionModalContent; context: { modal: modal }"></ng-container>
+  </ng-template>
+
+  <ng-template #titleModal let-modal>
+    <ng-container *ngTemplateOutlet="positionModalContent; context: { modal: modal }"></ng-container>
+  </ng-template>
+
+  <ng-template #positionModalContent let-modal="modal">
+    <div class="modal-header">
+      <h6 class="modal-title">{{ positionModalTitle }}</h6>
+      <button type="button" class="btn-close" aria-label="Close"
+        (click)="modal.dismiss('close'); resetPositionState()"></button>
+    </div>
+    <div class="modal-body">
+      <p class="text-muted small mb-3">{{ positionModalDescription }}</p>
+      <div *ngFor="let row of kpiPositionMatrix" class="d-flex justify-content-center mb-2">
+        <button type="button" class="btn m-1"
+          [ngClass]="selectedPosition === pos ? 'btn-primary' : 'btn-outline-secondary'"
+          (click)="selectKpiPosition(pos)"
+          *ngFor="let pos of row">
+          {{ pos.replace('-', ' ') | titlecase }}
+        </button>
+      </div>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-outline-secondary"
+        (click)="modal.dismiss('close'); resetPositionState()">Cancel</button>
+      <button type="button" class="btn btn-primary" (click)="confirmPositionSelection(modal)"
+        [disabled]="!selectedPosition">Save</button>
+    </div>
+  </ng-template>
 
   <ng-template #iconModal let-modal>
     <div class="modal-header">

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectorRef, Component, ElementRef, HostListener, QueryList, ViewChild, ViewChildren, OnDestroy, Input, SimpleChanges, Output, EventEmitter } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, HostListener, QueryList, ViewChild, ViewChildren, OnDestroy, Input, SimpleChanges, Output, EventEmitter, TemplateRef } from '@angular/core';
 import { NgbDropdown, NgbModal, NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { ResizableModule, ResizeEvent } from 'angular-resizable-element';
 import {CompactType, GridsterConfig, GridsterItem, GridsterItemComponent, GridsterItemComponentInterface, GridsterModule, GridsterPush, 
@@ -106,7 +106,7 @@ interface KpiData {
   kpiSuffix: string;
   kpiDecimalUnit : string;
   kpiDecimalPlaces: number;
-  trendData: [], 
+  trendData: [],
   trendLabels: [],
   kpiShowTrendline : boolean,
   showKpiIndicator : boolean,
@@ -114,7 +114,32 @@ interface KpiData {
   indicatorValue : any,
   kpiChartColor: string;
   kpiTarget: any;
+  kpiNumberPosition?: KpiPosition;
+  kpiTitlePosition?: KpiPosition;
 }
+
+type KpiPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'middle-left'
+  | 'middle-center'
+  | 'middle-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
+const KPI_POSITION_VALUES: KpiPosition[] = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'middle-left',
+  'middle-center',
+  'middle-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right'
+];
 declare var $:any;
 export class CustomVirtualScrollStrategy extends FixedSizeVirtualScrollStrategy {
   constructor() {
@@ -193,9 +218,22 @@ export class SheetsdashboardComponent implements OnDestroy {
  excludeFilterIdArray = [] as any;
  tablePreviewRow = [] as any;
  tablePreviewColumn =[] as any;
- filteredColumnData = [] as any;
- filteredRowData = [] as any;
- disableDashboardUpdate: boolean = false;
+  filteredColumnData = [] as any;
+  filteredRowData = [] as any;
+  readonly kpiPositionMatrix: KpiPosition[][] = [
+    ['top-left', 'top-center', 'top-right'],
+    ['middle-left', 'middle-center', 'middle-right'],
+    ['bottom-left', 'bottom-center', 'bottom-right']
+  ];
+  private readonly defaultKpiNumberPosition: KpiPosition = 'middle-center';
+  private readonly defaultKpiTitlePosition: KpiPosition = 'top-left';
+  selectedKpiItem: any = null;
+  positionTarget: 'number' | 'title' | null = null;
+  selectedPosition: KpiPosition | null = null;
+  positionModalTitle = '';
+  positionModalDescription = '';
+  positionFallback: KpiPosition = this.defaultKpiNumberPosition;
+  disableDashboardUpdate: boolean = false;
  sheetTabs : any[] = [];
  selectedTabIndex : number = 0;
  selectedTab : any = {};
@@ -951,6 +989,8 @@ export class SheetsdashboardComponent implements OnDestroy {
               indicatorIsIncreased : sheet.sheet_data?.results?.indicatorIsIncreased || '',
               indicatorValue : sheet.sheet_data?.results?.indicatorValue || '',
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
+              kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
+              kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
             };
             return this.kpiData; // Return the kpi object to kpiData
           })()
@@ -1088,6 +1128,9 @@ export class SheetsdashboardComponent implements OnDestroy {
   dynamicOptionsUpdateinDashboard(dashboard: any, isPublic: boolean, isTab?:boolean){
     let self = this;
     dashboard.forEach((sheet : any)=>{
+      if (this.isKpiChart(sheet)) {
+        this.ensureKpiPositionDefaults(sheet);
+      }
       // console.log('Before sanitization:', sheet.data?.sheetTagName);
       if(sheet.data?.sheetTagName){
         this.sheetTagTitle[sheet.data?.title] = this.sanitizer.bypassSecurityTrustHtml(sheet.data?.sheetTagName);
@@ -2122,6 +2165,8 @@ export class SheetsdashboardComponent implements OnDestroy {
               indicatorIsIncreased : sheet.sheet_data?.results?.indicatorIsIncreased || '',
               indicatorValue : sheet.sheet_data?.results?.indicatorValue || '',
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
+              kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
+              kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
 
           };
           return this.kpiData; // Return the kpi object to kpiData
@@ -2205,6 +2250,8 @@ export class SheetsdashboardComponent implements OnDestroy {
               indicatorIsIncreased : sheet.sheet_data?.results?.indicatorIsIncreased || '',
               indicatorValue : sheet.sheet_data?.results?.indicatorValue || '',
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
+              kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
+              kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
 
           };
           return this.kpiData; // Return the kpi object to kpiData
@@ -3945,6 +3992,7 @@ clearAllFilters(isSwitchDb?:boolean): void {
 setDashboardSheetData(item:any , isFilter : boolean , onApplyFilterClick : boolean, isDrillDown : boolean, isDrillThrough : boolean, drillThroughSheetId: any, isLiveReloadData : boolean,isLastIndex:boolean, dashboard : any[], isTabs?:boolean ,switchDb?: boolean,isDashboardTransfer?: boolean){
   dashboard.forEach((item1:any) => {
     if(item1.sheetId){
+      this.ensureKpiPositionDefaults(item1);
     if((((item1.sheetId == item.sheet_id || item1.sheetId == item.sheetId) && (isFilter || isDrillDown)) || (isDrillThrough && item1.sheetId == drillThroughSheetId))){
       if(item.chart_id == '1'){//table
         if(!item1.originalData && !isLiveReloadData && !switchDb){
@@ -5362,6 +5410,8 @@ kpiData?: KpiData;
               indicatorIsIncreased : sheet.sheet_data?.results?.indicatorIsIncreased || '',
               indicatorValue : sheet.sheet_data?.results?.indicatorValue || '',
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
+              kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
+              kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
             };
             return this.kpiData; // Return the kpi object to kpiData
           })()
@@ -7379,7 +7429,7 @@ validateTextEditor(): boolean {
     KpiIconItem:any;
     selectedIconFontSize: string = '24'; // Default size
     selectedIconColor: string = '#888'; // Default color
-    selectedIconPosition: string = 'bottom-right';
+    selectedIconPosition: KpiPosition = 'bottom-right';
     selectIcon(icon: any) {
       console.log('Selected Icon:', icon);
       this.selectedIcon = `${icon.styles[0]} fa-${icon.name}`;
@@ -7399,17 +7449,17 @@ validateTextEditor(): boolean {
     }
     positions = [
       { value: 'top-left', iconClass: 'dollar-top-left' },
-      { value: 'top-middle', iconClass: 'dollar-top-center' },
+      { value: 'top-center', iconClass: 'dollar-top-center' },
       { value: 'top-right', iconClass: 'dollar-top-right' },
-      { value: 'left-middle', iconClass: 'dollar-center-left' },
-      { value: 'center', iconClass: '' },
-      { value: 'right-middle', iconClass: 'dollar-center-right' },
+      { value: 'middle-left', iconClass: 'dollar-center-left' },
+      { value: 'middle-center', iconClass: '' },
+      { value: 'middle-right', iconClass: 'dollar-center-right' },
       { value: 'bottom-left', iconClass: 'dollar-bottom-left' },
-      { value: 'bottom-middle', iconClass: 'dollar-bottom-center' },
+      { value: 'bottom-center', iconClass: 'dollar-bottom-center' },
       { value: 'bottom-right', iconClass: 'dollar-bottom-right' }
     ];
     selectPosition(position: string): void {
-      this.selectedIconPosition = position;
+      this.selectedIconPosition = this.normalizePosition(position);
       console.log('kpiPosition',this.selectedIconPosition)
     }
     applyIconInKpi(){
@@ -7462,37 +7512,43 @@ validateTextEditor(): boolean {
     
     }
 
+    getPositionStyles(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition) {
+      const normalized = this.normalizePosition(position, fallback);
+      const map: Record<KpiPosition, any> = {
+        'top-left': { top: '0.5rem', left: '0.5rem' },
+        'top-center': { top: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
+        'top-right': { top: '0.5rem', right: '0.5rem' },
+        'middle-left': { top: '50%', left: '0.5rem', transform: 'translateY(-50%)' },
+        'middle-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' },
+        'middle-right': { top: '50%', right: '0.5rem', transform: 'translateY(-50%)' },
+        'bottom-left': { bottom: '0.5rem', left: '0.5rem' },
+        'bottom-center': { bottom: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
+        'bottom-right': { bottom: '0.5rem', right: '0.5rem' }
+      };
+      return { position: 'absolute', ...(map[normalized] || map[fallback]) };
+    }
     getIconPositionStyles(position: string) {
-      let styles = {};
-      const offset = '10px'; // Distance from the edges
-      switch (position) {
-          case 'top-left':
-            return { top: offset, left: offset, transform: 'none' };
-          case 'top-middle':
-            return { top: offset, left: '50%', transform: 'translateX(-50%)' };
-          case 'top-right':
-            return { top: offset, right: offset, transform: 'none' };
-          case 'left-middle':
-            return { top: '50%', left: offset, transform: 'translateY(-50%)' };
-          case 'center':
-            return { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' };
-          case 'right-middle':
-            return { top: '50%', right: offset, transform: 'translateY(-50%)' };
-          case 'bottom-left':
-            return { bottom: offset, left: offset, transform: 'none' };
-          case 'bottom-middle':
-            return { bottom: offset, left: '50%', transform: 'translateX(-50%)' };
-          case 'bottom-right':
-            return { bottom: offset, right: offset, transform: 'none' };
-        default:
-          styles = { bottom: '0', right: '0' }; 
-          break;
+      return this.getPositionStyles(position, 'bottom-right');
+    }
+    private normalizePosition(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition): KpiPosition {
+      if (!position) {
+        return fallback;
       }
-    
-      return styles;
+      const normalizedMap: Record<string, KpiPosition> = {
+        'top-middle': 'top-center',
+        'left-middle': 'middle-left',
+        'center': 'middle-center',
+        'right-middle': 'middle-right',
+        'bottom-middle': 'bottom-center'
+      };
+      const lowerPosition = (position || '').toLowerCase();
+      const candidate = normalizedMap[lowerPosition] || lowerPosition;
+      return KPI_POSITION_VALUES.includes(candidate as KpiPosition)
+        ? (candidate as KpiPosition)
+        : fallback;
     }
     getIconClass(icon: any): string {
-      return `${icon.styles[0]} fa-${icon.name}`; 
+      return `${icon.styles[0]} fa-${icon.name}`;
     }
     priorityIcons: string[] = ['arrow-trend-up','arrow-trend-down','house','magnifying-glass','user','facebook','check','download','twitter','instagram','envelope','linkedin','arrow-up','file','calendar-days','circle-down','address-book','handshake','layer-group','users','link','sack-dollar'
     ];; 
@@ -7515,6 +7571,136 @@ validateTextEditor(): boolean {
     this.showAll = !this.showAll;
     this.updateFilteredIcons();
   }
+  openLayoutModal(modalTemplate: TemplateRef<any>, item: any): void {
+    this.openPositionModal(
+      modalTemplate,
+      item,
+      'number',
+      this.defaultKpiNumberPosition,
+      'Edit KPI Layout',
+      'Choose where the KPI number should appear on the card.'
+    );
+  }
+  openTitleModal(modalTemplate: TemplateRef<any>, item: any): void {
+    this.openPositionModal(
+      modalTemplate,
+      item,
+      'title',
+      this.defaultKpiTitlePosition,
+      'Edit KPI Title',
+      'Choose where the KPI title should appear on the card.'
+    );
+  }
+  private openPositionModal(
+    modalTemplate: TemplateRef<any>,
+    item: any,
+    target: 'number' | 'title',
+    fallback: KpiPosition,
+    title: string,
+    description: string
+  ): void {
+    if (!item) {
+      return;
+    }
+    this.ensureKpiPositionDefaults(item);
+    this.selectedKpiItem = item;
+    this.positionTarget = target;
+    this.positionFallback = fallback;
+    this.positionModalTitle = title;
+    this.positionModalDescription = description;
+    const currentPosition = target === 'number'
+      ? item.kpiData?.kpiNumberPosition
+      : item.kpiData?.kpiTitlePosition;
+    this.selectedPosition = this.normalizePosition(currentPosition, fallback);
+    this.modalService.open(modalTemplate, {
+      backdrop: 'static',
+      centered: true,
+      windowClass: 'animate__animated animate__zoomIn'
+    });
+  }
+  selectKpiPosition(position: KpiPosition): void {
+    this.selectedPosition = this.normalizePosition(position, this.positionFallback);
+  }
+  confirmPositionSelection(modal: any): void {
+    if (!this.selectedKpiItem || !this.positionTarget) {
+      this.resetPositionState();
+      modal.dismiss('close');
+      return;
+    }
+    const positionToSave = this.selectedPosition ?? this.positionFallback;
+    this.applyKpiPosition(this.selectedKpiItem, this.positionTarget, positionToSave);
+    modal.close('save');
+    this.resetPositionState();
+  }
+  resetPositionState(): void {
+    this.selectedKpiItem = null;
+    this.positionTarget = null;
+    this.selectedPosition = null;
+    this.positionModalTitle = '';
+    this.positionModalDescription = '';
+    this.positionFallback = this.defaultKpiNumberPosition;
+  }
+  private applyKpiPosition(item: any, target: 'number' | 'title', position: KpiPosition): void {
+    const field = target === 'number' ? 'kpiNumberPosition' : 'kpiTitlePosition';
+    const normalized = this.normalizePosition(
+      position,
+      target === 'number' ? this.defaultKpiNumberPosition : this.defaultKpiTitlePosition
+    );
+    if (!item.kpiData) {
+      item.kpiData = {};
+    }
+    item.kpiData[field] = normalized;
+    const updateCollection = (collection?: any[]) => {
+      if (!collection) {
+        return null;
+      }
+      const index = collection.findIndex((d: any) => d['id'] === item.id);
+      if (index === -1) {
+        return null;
+      }
+      const existingItem = collection[index];
+      const updatedItem = {
+        ...existingItem,
+        kpiData: {
+          ...(existingItem.kpiData || {}),
+          [field]: normalized
+        }
+      };
+      collection[index] = updatedItem;
+      return updatedItem;
+    };
+    let updatedItem = updateCollection(this.dashboard);
+    if (this.displayTabs && this.sheetTabs && this.sheetTabs.length > 0 && this.selectedTabIndex >= 0) {
+      const tabDashboard = this.sheetTabs[this.selectedTabIndex]?.dashboard;
+      const tabUpdatedItem = updateCollection(tabDashboard);
+      if (tabUpdatedItem) {
+        updatedItem = tabUpdatedItem;
+      }
+    }
+    if (updatedItem) {
+      this.selectedKpiItem = updatedItem;
+    }
+    this.canNavigateToAnotherPage = true;
+  }
+  private ensureKpiPositionDefaults(item: any): void {
+    if (!this.isKpiChart(item)) {
+      return;
+    }
+    if (!item.kpiData) {
+      item.kpiData = {};
+    }
+    item.kpiData.kpiNumberPosition = this.normalizePosition(
+      item.kpiData.kpiNumberPosition,
+      this.defaultKpiNumberPosition
+    );
+    item.kpiData.kpiTitlePosition = this.normalizePosition(
+      item.kpiData.kpiTitlePosition,
+      this.defaultKpiTitlePosition
+    );
+  }
+  private isKpiChart(item: any): boolean {
+    return !!item && (item.chartId == 25 || item.chart_id == 25);
+  }
   editKpiIcon(iconModal:any,item:any){
     this.modalService.open(iconModal, {
       centered: true,
@@ -7525,7 +7711,7 @@ validateTextEditor(): boolean {
     const kpiIconsArray = item.kpiIconsArray
     this.selectedIconColor = kpiIconsArray.kpiIconColor ?? '#888'
     this.selectedIconFontSize = kpiIconsArray.kpiIconSize ?? '24'
-    this.selectedIconPosition = kpiIconsArray.kpiIconPosition ?? 'bottom-right'
+    this.selectedIconPosition = this.normalizePosition(kpiIconsArray.kpiIconPosition ?? 'bottom-right')
     this.selectedIcon = kpiIconsArray.kpiIcon ?? null
  
   }

--- a/src/app/services/dashboard-transfer.service.ts
+++ b/src/app/services/dashboard-transfer.service.ts
@@ -6,6 +6,18 @@ import { SheetsComponent } from '../components/workbench/sheets/sheets.component
 import { SheetsdashboardComponent } from '../components/workbench/sheetsdashboard/sheetsdashboard.component';
 import { WorkbenchService } from '../components/workbench/workbench.service';
 
+const KPI_POSITION_VALUES = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'middle-left',
+  'middle-center',
+  'middle-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right'
+];
+
 @Injectable({
   providedIn: 'root'
 })
@@ -16,6 +28,30 @@ export class DashboardTransferService {
   dashboardInstance! : SheetsdashboardComponent;
 
   constructor(private workbechService: WorkbenchService, private toasterservice: ToastrService) { }
+
+  private ensureKpiPositionDefaults(item: any): void {
+    if (!item || !item.kpiData) {
+      return;
+    }
+    item.kpiData.kpiNumberPosition = this.normalizePosition(item.kpiData.kpiNumberPosition, 'middle-center');
+    item.kpiData.kpiTitlePosition = this.normalizePosition(item.kpiData.kpiTitlePosition, 'top-left');
+  }
+
+  private normalizePosition(position?: string | null, fallback: string = 'middle-center'): string {
+    if (!position) {
+      return fallback;
+    }
+    const normalizedMap: Record<string, string> = {
+      'top-middle': 'top-center',
+      'left-middle': 'middle-left',
+      'center': 'middle-center',
+      'right-middle': 'middle-right',
+      'bottom-middle': 'bottom-center'
+    };
+    const lower = (position || '').toLowerCase();
+    const candidate = normalizedMap[lower] || lower;
+    return KPI_POSITION_VALUES.includes(candidate) ? candidate : fallback;
+  }
 
     buildDashboardTransfer(container: ViewContainerRef,responesData : any){
     const componentRef =container.createComponent(SheetsComponent);
@@ -463,6 +499,7 @@ export class DashboardTransferService {
       dashboard.dashboard_data.forEach((dashboardItem:any) => {
         if (dashboardItem.sheetId === sheetId) {
           if(dashboardItem.chartId == 25 || sheet.chart_id == 25){
+            this.ensureKpiPositionDefaults(dashboardItem);
             dashboardItem.kpiData.kpiNumber = sheet.sheet_data.results.kpiNumber
             dashboardItem.kpiData.rows = sheet.dashboardKPIRows;
           } else if(dashboardItem.chartId == 1 || sheet.chart_id == 1){
@@ -488,6 +525,7 @@ export class DashboardTransferService {
           tabData.dashboard?.forEach((dashboardItem: any) => {
             if (dashboardItem.sheetId === sheetId) {
               if (dashboardItem.chartId == 25 || sheet.chart_id == 25) {
+                this.ensureKpiPositionDefaults(dashboardItem);
                 dashboardItem.kpiData.kpiNumber = sheet.sheet_data.results.kpiNumber
                 dashboardItem.kpiData.rows = sheet.dashboardKPIRows;
               } else if (dashboardItem.chartId == 1 || sheet.chart_id == 1) {


### PR DESCRIPTION
## Summary
- add dropdown actions and modal workflows to edit KPI number layout and sheet title placement independently
- render KPI numbers, titles, and icons with shared absolute positioning utilities and default fallbacks
- normalize KPI position data during dashboard hydration and transfer to preserve layout settings

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68e40c88e38c832093443b81d391207e