### PR TITLE
feat: allow editing KPI trendline layout

### DIFF
--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.html
@@ -1329,6 +1329,9 @@
                           [classesList]="'dropdown-item'" [buttonName]="'Edit Number Layout'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="openLayoutModal(layoutModal, item)" [isIcon]="false"></app-insights-button>
                         <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit TrendLine Layout'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openTrendlineModal(trendlineModal, item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
                           [classesList]="'dropdown-item'" [buttonName]="'Edit Title Layout'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="openTitleModal(titleModal, item)" [isIcon]="false"></app-insights-button>
                           <app-insights-button 
@@ -1641,32 +1644,36 @@
                     </div>
                     @for(row of item['kpiData'].rows;track row){
                     <ng-container *ngIf="row?.result_data">
-                      <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted" [style.color]="item['kpiData']?.color" style="font-size: 13px;">
-                        Target: {{ item['kpiData']?.kpiTarget }}
-                      </div>
-                      <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
-                          [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
-                          [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
-                          [stroke]="{ curve: 'smooth', width: 2 }"
-                          [colors]="[item['kpiData']?.kpiChartColor]"
-                          [tooltip]="{ enabled: true }"
-                          [xaxis]="{ categories: item['kpiData']?.trendLabels}"
-                          style="margin-top: 5px;">
-                        </apx-chart>
-                        <div *ngIf="item['kpiData']?.showKpiIndicator"
-                            class="d-flex justify-content-around mt-2 flex-wrap text-center"
-                            style="font-size: 12px;">
-                          <span [ngStyle]="{
-                                  color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
-                                  fontWeight: 'bold'
-                                }">
-                            <i class="bi"
-                              [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
-                                              ? 'bi-arrow-up'
-                                              : 'bi-arrow-down'"></i>
-                            {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
-                          </span>
+                      <div class="trendline-block"
+                        [ngStyle]="getTrendlinePositionStyles(item['kpiData']?.kpiTrendlinePosition)">
+                        <div *ngIf="item['kpiData']?.showKpiIndicator" class="text-center text-muted"
+                          [style.color]="item['kpiData']?.color" style="font-size: 13px;">
+                          Target: {{ item['kpiData']?.kpiTarget }}
                         </div>
+                        <apx-chart *ngIf="item['kpiData']?.trendData && item['kpiData']?.kpiShowTrendline "
+                            [series]="[{ name: 'KPI Trend',data:item['kpiData']?.trendData  }]"
+                            [chart]="{ type: 'line', height: 50, sparkline: { enabled: true } }"
+                            [stroke]="{ curve: 'smooth', width: 2 }"
+                            [colors]="[item['kpiData']?.kpiChartColor]"
+                            [tooltip]="{ enabled: true }"
+                            [xaxis]="{ categories: item['kpiData']?.trendLabels}"
+                            style="margin-top: 5px;">
+                          </apx-chart>
+                          <div *ngIf="item['kpiData']?.showKpiIndicator"
+                              class="d-flex justify-content-around mt-2 flex-wrap text-center"
+                              style="font-size: 12px;">
+                            <span [ngStyle]="{
+                                    color: item['kpiData']?.indicatorIsIncreased === 'up' ? 'green' : 'red',
+                                    fontWeight: 'bold'
+                                  }">
+                              <i class="bi"
+                                [ngClass]="item['kpiData']?.indicatorIsIncreased === 'up'
+                                                ? 'bi-arrow-up'
+                                                : 'bi-arrow-down'"></i>
+                              {{ item['kpiData']?.indicatorValue }}% {{ item['kpiData']?.indicatorIsIncreased === 'up' ? 'above target' : 'below target' }}
+                            </span>
+                          </div>
+                      </div>
                     </ng-container>
                     }
                     <i [class]="item['kpiIconsArray']?.kpiIcon" [style.font-size]="item['kpiIconsArray']?.kpiIconSize + 'px'"
@@ -1923,6 +1930,9 @@
                         <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
                           [classesList]="'dropdown-item'" [buttonName]="'Edit Number Layout'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="openLayoutModal(layoutModal, item)" [isIcon]="false"></app-insights-button>
+                        <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
+                          [classesList]="'dropdown-item'" [buttonName]="'Edit TrendLine Layout'" [previledgeId]="37" [isBtn]="false"
+                          (btnClickEvent)="openTrendlineModal(trendlineModal, item)" [isIcon]="false"></app-insights-button>
                         <app-insights-button *ngIf="!isPublicUrl && item['chartId'] === 25"
                           [classesList]="'dropdown-item'" [buttonName]="'Edit Title Layout'" [previledgeId]="37" [isBtn]="false"
                           (btnClickEvent)="openTitleModal(titleModal, item)" [isIcon]="false"></app-insights-button>
@@ -2367,6 +2377,10 @@
     <ng-container *ngTemplateOutlet="positionModalContent; context: { modal: modal }"></ng-container>
   </ng-template>
 
+  <ng-template #trendlineModal let-modal>
+    <ng-container *ngTemplateOutlet="positionModalContent; context: { modal: modal }"></ng-container>
+  </ng-template>
+
   <ng-template #positionModalContent let-modal="modal">
     <div class="modal-header">
       <h6 class="modal-title">{{ positionModalTitle }}</h6>
@@ -2375,14 +2389,26 @@
     </div>
     <div class="modal-body">
       <p class="text-muted small mb-3">{{ positionModalDescription }}</p>
-      <div *ngFor="let row of kpiPositionMatrix" class="d-flex justify-content-center mb-2">
-        <button type="button" class="btn m-1"
-          [ngClass]="selectedPosition === pos ? 'btn-primary' : 'btn-outline-secondary'"
-          (click)="selectKpiPosition(pos)"
-          *ngFor="let pos of row">
-          {{ pos.replace('-', ' ') | titlecase }}
-        </button>
-      </div>
+      <ng-container *ngIf="positionTarget === 'trendline'; else positionGrid">
+        <div class="d-flex justify-content-center flex-wrap">
+          <button type="button" class="btn m-1"
+            *ngFor="let pos of trendlinePositionOptions"
+            [ngClass]="selectedPosition === pos ? 'btn-primary' : 'btn-outline-secondary'"
+            (click)="selectKpiPosition(pos)">
+            {{ pos | titlecase }}
+          </button>
+        </div>
+      </ng-container>
+      <ng-template #positionGrid>
+        <div *ngFor="let row of kpiPositionMatrix" class="d-flex justify-content-center mb-2">
+          <button type="button" class="btn m-1"
+            [ngClass]="selectedPosition === pos ? 'btn-primary' : 'btn-outline-secondary'"
+            (click)="selectKpiPosition(pos)"
+            *ngFor="let pos of row">
+            {{ pos.replace('-', ' ') | titlecase }}
+          </button>
+        </div>
+      </ng-template>
     </div>
     <div class="modal-footer">
       <button type="button" class="btn btn-outline-secondary"

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.scss
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.scss
@@ -118,6 +118,18 @@ button.BtnNewStyle { margin-inline: 0px !important; border-radius: 0px !importan
 .table thead th{ color: #333335;}
 th, td { border: 1px solid #ddd;}
 .big-number-container { display:contents;}
+
+.trendline-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 0.25rem 0;
+}
+
+.trendline-block apx-chart {
+  width: 100%;
+}
 .big-number {  font-size: 4rem; /* Adjust the size as needed */  font-weight: bold;  color: #007bff; /* Example color */}
 .selected-icon { border: 2px solid #007bff; /* Blue border when selected */ background-color: #f0f8ff; /* Light blue background when selected */  box-shadow: 0px 0px 5px rgba(0, 123, 255, 0.5); /* Optional box-shadow effect */ }
 .icon-container:hover { background-color: #f0f0f0; }

--- a/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
+++ b/src/app/components/workbench/sheetsdashboard/sheetsdashboard.component.ts
@@ -116,6 +116,7 @@ interface KpiData {
   kpiTarget: any;
   kpiNumberPosition?: KpiPosition;
   kpiTitlePosition?: KpiPosition;
+  kpiTrendlinePosition?: KpiTrendlinePosition;
 }
 
 type KpiPosition =
@@ -129,6 +130,8 @@ type KpiPosition =
   | 'bottom-center'
   | 'bottom-right';
 
+type KpiTrendlinePosition = 'top' | 'center' | 'bottom';
+
 const KPI_POSITION_VALUES: KpiPosition[] = [
   'top-left',
   'top-center',
@@ -140,6 +143,8 @@ const KPI_POSITION_VALUES: KpiPosition[] = [
   'bottom-center',
   'bottom-right'
 ];
+
+const KPI_TRENDLINE_POSITION_VALUES: KpiTrendlinePosition[] = ['top', 'center', 'bottom'];
 declare var $:any;
 export class CustomVirtualScrollStrategy extends FixedSizeVirtualScrollStrategy {
   constructor() {
@@ -225,14 +230,16 @@ export class SheetsdashboardComponent implements OnDestroy {
     ['middle-left', 'middle-center', 'middle-right'],
     ['bottom-left', 'bottom-center', 'bottom-right']
   ];
+  readonly trendlinePositionOptions: KpiTrendlinePosition[] = ['top', 'center', 'bottom'];
   private readonly defaultKpiNumberPosition: KpiPosition = 'middle-center';
   private readonly defaultKpiTitlePosition: KpiPosition = 'top-left';
+  private readonly defaultKpiTrendlinePosition: KpiTrendlinePosition = 'bottom';
   selectedKpiItem: any = null;
-  positionTarget: 'number' | 'title' | null = null;
-  selectedPosition: KpiPosition | null = null;
+  positionTarget: 'number' | 'title' | 'trendline' | null = null;
+  selectedPosition: (KpiPosition | KpiTrendlinePosition) | null = null;
   positionModalTitle = '';
   positionModalDescription = '';
-  positionFallback: KpiPosition = this.defaultKpiNumberPosition;
+  positionFallback: KpiPosition | KpiTrendlinePosition = this.defaultKpiNumberPosition;
   disableDashboardUpdate: boolean = false;
  sheetTabs : any[] = [];
  selectedTabIndex : number = 0;
@@ -991,6 +998,7 @@ export class SheetsdashboardComponent implements OnDestroy {
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
               kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
               kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
+              kpiTrendlinePosition: this.normalizeTrendlinePosition(sheet.sheet_data?.results?.kpiTrendlinePosition, this.defaultKpiTrendlinePosition),
             };
             return this.kpiData; // Return the kpi object to kpiData
           })()
@@ -2167,6 +2175,7 @@ export class SheetsdashboardComponent implements OnDestroy {
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
               kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
               kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
+              kpiTrendlinePosition: this.normalizeTrendlinePosition(sheet.sheet_data?.results?.kpiTrendlinePosition, this.defaultKpiTrendlinePosition),
 
           };
           return this.kpiData; // Return the kpi object to kpiData
@@ -2252,6 +2261,7 @@ export class SheetsdashboardComponent implements OnDestroy {
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
               kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
               kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
+              kpiTrendlinePosition: this.normalizeTrendlinePosition(sheet.sheet_data?.results?.kpiTrendlinePosition, this.defaultKpiTrendlinePosition),
 
           };
           return this.kpiData; // Return the kpi object to kpiData
@@ -5412,6 +5422,7 @@ kpiData?: KpiData;
               kpiTarget : sheet.sheet_data?.results?.kpiTarget || 0,
               kpiNumberPosition: this.normalizePosition(sheet.sheet_data?.results?.kpiNumberPosition, this.defaultKpiNumberPosition),
               kpiTitlePosition: this.normalizePosition(sheet.sheet_data?.results?.kpiTitlePosition, this.defaultKpiTitlePosition),
+              kpiTrendlinePosition: this.normalizeTrendlinePosition(sheet.sheet_data?.results?.kpiTrendlinePosition, this.defaultKpiTrendlinePosition),
             };
             return this.kpiData; // Return the kpi object to kpiData
           })()
@@ -7512,41 +7523,72 @@ validateTextEditor(): boolean {
     
     }
 
-    getPositionStyles(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition) {
-      const normalized = this.normalizePosition(position, fallback);
-      const map: Record<KpiPosition, any> = {
-        'top-left': { top: '0.5rem', left: '0.5rem' },
-        'top-center': { top: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
-        'top-right': { top: '0.5rem', right: '0.5rem' },
-        'middle-left': { top: '50%', left: '0.5rem', transform: 'translateY(-50%)' },
-        'middle-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' },
-        'middle-right': { top: '50%', right: '0.5rem', transform: 'translateY(-50%)' },
-        'bottom-left': { bottom: '0.5rem', left: '0.5rem' },
-        'bottom-center': { bottom: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
-        'bottom-right': { bottom: '0.5rem', right: '0.5rem' }
-      };
-      return { position: 'absolute', ...(map[normalized] || map[fallback]) };
+  getPositionStyles(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition) {
+    const normalized = this.normalizePosition(position, fallback);
+    const map: Record<KpiPosition, any> = {
+      'top-left': { top: '0.5rem', left: '0.5rem' },
+      'top-center': { top: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
+      'top-right': { top: '0.5rem', right: '0.5rem' },
+      'middle-left': { top: '50%', left: '0.5rem', transform: 'translateY(-50%)' },
+      'middle-center': { top: '50%', left: '50%', transform: 'translate(-50%, -50%)' },
+      'middle-right': { top: '50%', right: '0.5rem', transform: 'translateY(-50%)' },
+      'bottom-left': { bottom: '0.5rem', left: '0.5rem' },
+      'bottom-center': { bottom: '0.5rem', left: '50%', transform: 'translateX(-50%)' },
+      'bottom-right': { bottom: '0.5rem', right: '0.5rem' }
+    };
+    return { position: 'absolute', ...(map[normalized] || map[fallback]) };
+  }
+  getTrendlinePositionStyles(
+    position?: string | null,
+    fallback: KpiTrendlinePosition = this.defaultKpiTrendlinePosition
+  ) {
+    const normalized = this.normalizeTrendlinePosition(position, fallback);
+    const map: Record<KpiTrendlinePosition, any> = {
+      top: { top: '0.5rem', transform: 'translateX(-50%)' },
+      center: { top: '50%', transform: 'translate(-50%, -50%)' },
+      bottom: { bottom: '0.5rem', transform: 'translateX(-50%)' }
+    };
+    const styles = map[normalized] || map[fallback];
+    return {
+      position: 'absolute',
+      left: '50%',
+      width: '90%',
+      maxWidth: '100%',
+      ...(styles ?? {})
+    };
+  }
+  getIconPositionStyles(position: string) {
+    return this.getPositionStyles(position, 'bottom-right');
+  }
+  private normalizePosition(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition): KpiPosition {
+    if (!position) {
+      return fallback;
     }
-    getIconPositionStyles(position: string) {
-      return this.getPositionStyles(position, 'bottom-right');
-    }
-    private normalizePosition(position?: string | null, fallback: KpiPosition = this.defaultKpiNumberPosition): KpiPosition {
-      if (!position) {
-        return fallback;
-      }
-      const normalizedMap: Record<string, KpiPosition> = {
-        'top-middle': 'top-center',
+    const normalizedMap: Record<string, KpiPosition> = {
+      'top-middle': 'top-center',
         'left-middle': 'middle-left',
         'center': 'middle-center',
         'right-middle': 'middle-right',
         'bottom-middle': 'bottom-center'
       };
       const lowerPosition = (position || '').toLowerCase();
-      const candidate = normalizedMap[lowerPosition] || lowerPosition;
-      return KPI_POSITION_VALUES.includes(candidate as KpiPosition)
-        ? (candidate as KpiPosition)
-        : fallback;
+    const candidate = normalizedMap[lowerPosition] || lowerPosition;
+    return KPI_POSITION_VALUES.includes(candidate as KpiPosition)
+      ? (candidate as KpiPosition)
+      : fallback;
+  }
+  private normalizeTrendlinePosition(
+    position?: string | null,
+    fallback: KpiTrendlinePosition = this.defaultKpiTrendlinePosition
+  ): KpiTrendlinePosition {
+    if (!position) {
+      return fallback;
     }
+    const lower = (position || '').toLowerCase();
+    return KPI_TRENDLINE_POSITION_VALUES.includes(lower as KpiTrendlinePosition)
+      ? (lower as KpiTrendlinePosition)
+      : fallback;
+  }
     getIconClass(icon: any): string {
       return `${icon.styles[0]} fa-${icon.name}`;
     }
@@ -7591,11 +7633,21 @@ validateTextEditor(): boolean {
       'Choose where the KPI title should appear on the card.'
     );
   }
+  openTrendlineModal(modalTemplate: TemplateRef<any>, item: any): void {
+    this.openPositionModal(
+      modalTemplate,
+      item,
+      'trendline',
+      this.defaultKpiTrendlinePosition,
+      'Edit Trendline Layout',
+      'Choose where the KPI trendline and indicator should appear on the card.'
+    );
+  }
   private openPositionModal(
     modalTemplate: TemplateRef<any>,
     item: any,
-    target: 'number' | 'title',
-    fallback: KpiPosition,
+    target: 'number' | 'title' | 'trendline',
+    fallback: KpiPosition | KpiTrendlinePosition,
     title: string,
     description: string
   ): void {
@@ -7610,16 +7662,26 @@ validateTextEditor(): boolean {
     this.positionModalDescription = description;
     const currentPosition = target === 'number'
       ? item.kpiData?.kpiNumberPosition
-      : item.kpiData?.kpiTitlePosition;
-    this.selectedPosition = this.normalizePosition(currentPosition, fallback);
+      : target === 'title'
+        ? item.kpiData?.kpiTitlePosition
+        : item.kpiData?.kpiTrendlinePosition;
+    if (target === 'trendline') {
+      this.selectedPosition = this.normalizeTrendlinePosition(currentPosition, fallback as KpiTrendlinePosition);
+    } else {
+      this.selectedPosition = this.normalizePosition(currentPosition, fallback as KpiPosition);
+    }
     this.modalService.open(modalTemplate, {
       backdrop: 'static',
       centered: true,
       windowClass: 'animate__animated animate__zoomIn'
     });
   }
-  selectKpiPosition(position: KpiPosition): void {
-    this.selectedPosition = this.normalizePosition(position, this.positionFallback);
+  selectKpiPosition(position: KpiPosition | KpiTrendlinePosition): void {
+    if (this.positionTarget === 'trendline') {
+      this.selectedPosition = this.normalizeTrendlinePosition(position, this.positionFallback as KpiTrendlinePosition);
+    } else {
+      this.selectedPosition = this.normalizePosition(position, this.positionFallback as KpiPosition);
+    }
   }
   confirmPositionSelection(modal: any): void {
     if (!this.selectedKpiItem || !this.positionTarget) {
@@ -7640,12 +7702,23 @@ validateTextEditor(): boolean {
     this.positionModalDescription = '';
     this.positionFallback = this.defaultKpiNumberPosition;
   }
-  private applyKpiPosition(item: any, target: 'number' | 'title', position: KpiPosition): void {
-    const field = target === 'number' ? 'kpiNumberPosition' : 'kpiTitlePosition';
-    const normalized = this.normalizePosition(
-      position,
-      target === 'number' ? this.defaultKpiNumberPosition : this.defaultKpiTitlePosition
-    );
+  private applyKpiPosition(
+    item: any,
+    target: 'number' | 'title' | 'trendline',
+    position: KpiPosition | KpiTrendlinePosition
+  ): void {
+    let field: 'kpiNumberPosition' | 'kpiTitlePosition' | 'kpiTrendlinePosition';
+    let normalized: KpiPosition | KpiTrendlinePosition;
+    if (target === 'trendline') {
+      field = 'kpiTrendlinePosition';
+      normalized = this.normalizeTrendlinePosition(position, this.defaultKpiTrendlinePosition);
+    } else {
+      field = target === 'number' ? 'kpiNumberPosition' : 'kpiTitlePosition';
+      normalized = this.normalizePosition(
+        position as KpiPosition,
+        target === 'number' ? this.defaultKpiNumberPosition : this.defaultKpiTitlePosition
+      );
+    }
     if (!item.kpiData) {
       item.kpiData = {};
     }
@@ -7696,6 +7769,10 @@ validateTextEditor(): boolean {
     item.kpiData.kpiTitlePosition = this.normalizePosition(
       item.kpiData.kpiTitlePosition,
       this.defaultKpiTitlePosition
+    );
+    item.kpiData.kpiTrendlinePosition = this.normalizeTrendlinePosition(
+      item.kpiData.kpiTrendlinePosition,
+      this.defaultKpiTrendlinePosition
     );
   }
   private isKpiChart(item: any): boolean {

--- a/src/app/services/dashboard-transfer.service.ts
+++ b/src/app/services/dashboard-transfer.service.ts
@@ -18,6 +18,8 @@ const KPI_POSITION_VALUES = [
   'bottom-right'
 ];
 
+const KPI_TRENDLINE_POSITION_VALUES = ['top', 'center', 'bottom'];
+
 @Injectable({
   providedIn: 'root'
 })
@@ -35,6 +37,7 @@ export class DashboardTransferService {
     }
     item.kpiData.kpiNumberPosition = this.normalizePosition(item.kpiData.kpiNumberPosition, 'middle-center');
     item.kpiData.kpiTitlePosition = this.normalizePosition(item.kpiData.kpiTitlePosition, 'top-left');
+    item.kpiData.kpiTrendlinePosition = this.normalizeTrendlinePosition(item.kpiData.kpiTrendlinePosition, 'bottom');
   }
 
   private normalizePosition(position?: string | null, fallback: string = 'middle-center'): string {
@@ -51,6 +54,14 @@ export class DashboardTransferService {
     const lower = (position || '').toLowerCase();
     const candidate = normalizedMap[lower] || lower;
     return KPI_POSITION_VALUES.includes(candidate) ? candidate : fallback;
+  }
+
+  private normalizeTrendlinePosition(position?: string | null, fallback: string = 'bottom'): string {
+    if (!position) {
+      return fallback;
+    }
+    const lower = (position || '').toLowerCase();
+    return KPI_TRENDLINE_POSITION_VALUES.includes(lower) ? lower : fallback;
   }
 
     buildDashboardTransfer(container: ViewContainerRef,responesData : any){


### PR DESCRIPTION
## Summary
- add a TrendLine layout option to KPI dashboards alongside the existing number/title editors
- allow positioning the target/trend/indicator block within KPI tiles via reusable modal controls and new styling helpers
- persist the chosen trendline position in KPI data initialization and dashboard transfer defaults

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e64a4053088320af16d997e08bbdb8