### PR TITLE
feat: add legend controls to dual-axis charts

### DIFF
--- a/src/app/components/workbench/insight-apex/insight-apex.component.ts
+++ b/src/app/components/workbench/insight-apex/insight-apex.component.ts
@@ -105,6 +105,86 @@ export class InsightApexComponent {
   formattedData : any[] = [];
   guageNumber : any;
   radialRawValues: any[] = [];
+  private readonly legendSupportedChartTypes = new Set([
+    'pie',
+    'donut',
+    'radial',
+    'sidebyside',
+    'sidesidebar',
+    'stocked',
+    'stacked',
+    'barline',
+    'hstocked',
+    'hstacked',
+    'hgrouped',
+    'multiline'
+  ]);
+
+  private getApexLegendConfig(): any {
+    const legend: any = {
+      show: this.legendSwitch,
+      position: this.legendsAllignment
+    };
+
+    if (['top', 'bottom'].includes(this.legendsAllignment)) {
+      legend.horizontalAlign = 'center';
+      legend.offsetY = 0;
+    } else {
+      legend.offsetY = this.legendsAllignment === 'right' ? 40 : 0;
+    }
+
+    return legend;
+  }
+
+  private applyApexLegendConfiguration(): void {
+    if (!this.chartOptions || !this.legendSupportedChartTypes.has(this.chartType ?? '')) {
+      return;
+    }
+
+    const legendConfig = this.getApexLegendConfig();
+    this.chartOptions.legend = { ...(this.chartOptions.legend ?? {}), ...legendConfig };
+
+    if (!['top', 'bottom'].includes(this.legendsAllignment)) {
+      delete this.chartOptions.legend.horizontalAlign;
+    }
+
+    const object = { legend: this.chartOptions.legend };
+
+    switch (this.chartType) {
+      case 'pie':
+        this.pieCharts?.updateOptions(object);
+        break;
+      case 'donut':
+        this.donutCharts?.updateOptions(object);
+        break;
+      case 'radial':
+        this.radialCharts?.updateOptions(object);
+        break;
+      case 'sidebyside':
+      case 'sidesidebar':
+        this.sideBySideCharts?.updateOptions(object);
+        break;
+      case 'stocked':
+      case 'stacked':
+        this.stockedCharts?.updateOptions(object);
+        break;
+      case 'barline':
+        this.barLineCharts?.updateOptions(object);
+        break;
+      case 'hstocked':
+      case 'hstacked':
+        this.horizontalStockedCharts?.updateOptions(object);
+        break;
+      case 'hgrouped':
+        this.groupedCharts?.updateOptions(object);
+        break;
+      case 'multiline':
+        this.multiLineCharts?.updateOptions(object);
+        break;
+      default:
+        break;
+    }
+  }
 
   ngOnInit(){
     // this.generateChart();
@@ -185,7 +265,7 @@ export class InsightApexComponent {
     if(changes['yGridSwitch']){
       this.yGridShowOrHide();
     }
-    if(['donut','pie','radial'].includes(this.chartType) && changes['legendSwitch']){
+    if(this.legendSupportedChartTypes.has(this.chartType ?? '') && changes['legendSwitch']){
       this.legendsShowOrHide();
     }
     if(['donut','pie','treemap'].includes(this.chartType) && changes['dataLabels']){
@@ -197,7 +277,7 @@ export class InsightApexComponent {
     if(['bar','funnel','horizontalBar','radial'].includes(this.chartType) && changes['isDistributed']){
       this.colorDistribution();
     }
-    if(['donut','pie','radial'].includes(this.chartType) && changes['legendsAllignment']){
+    if(this.legendSupportedChartTypes.has(this.chartType ?? '') && changes['legendsAllignment']){
       this.legendPositionChange();
     }
     if(this.chartType == 'donut' && changes['donutSize']){
@@ -1044,10 +1124,7 @@ xaxis: {
       },
       colors:this.isMeasureDistribution ? this.setColorsOnRanges(this.chartsRowData ) : this.selectedColorScheme,
       labels: this.chartsColumnData.map((category: any) => category === null ? 'null' : category),
-      legend: {
-        show: this.legendSwitch,
-        position: this.legendsAllignment
-      },
+      legend: this.getApexLegendConfig(),
       dataLabels: {
         enabled: this.dataLabels,
         dropShadow: {
@@ -1096,12 +1173,13 @@ xaxis: {
             pan: true,
             reset: true || '<img src="./assets/images/icons/home-icon.png" width="20">',
           },
-          autoSelected: 'zoom' 
+          autoSelected: 'zoom'
         },
         type: 'bar',
         height: 320,
         background: this.backgroundColor,
       },
+      legend: this.getApexLegendConfig(),
       plotOptions: {
         bar: {
           horizontal: false,
@@ -1271,10 +1349,7 @@ xaxis: {
           formatter: this.formatNumber.bind(this)
         }
       },
-      legend: {
-        position: "right",
-        offsetY: 40
-      },
+      legend: this.getApexLegendConfig(),
       fill: {
         opacity: 1
       },
@@ -1368,12 +1443,13 @@ xaxis: {
             pan: true,
             reset: true || '<img src="./assets/images/icons/home-icon.png" width="20">',
           },
-          autoSelected: 'zoom' 
+          autoSelected: 'zoom'
         },
         height: 350,
         type: "line",
         background: this.backgroundColor
       },
+      legend: this.getApexLegendConfig(),
       grid: {
         show: true,
         borderColor: this.gridColor,
@@ -1558,10 +1634,7 @@ xaxis: {
           },
         }
       },
-      legend: {
-        position: "right",
-        offsetY: 40
-      },
+      legend: this.getApexLegendConfig(),
       fill: {
         opacity: 1
       },
@@ -1745,6 +1818,7 @@ xaxis: {
         align: "left"
       },
       legend: {
+        ...this.getApexLegendConfig(),
         tooltipHoverFormatter: function (val: any, opts: any) {
           return (
             val +
@@ -2141,9 +2215,7 @@ xaxis: {
       xaxis: {
         categories: categories
       },
-      legend: {
-        show: false
-      },
+      legend: this.getApexLegendConfig(),
       colors: this.isMeasureDistribution ? this.setColorsOnRanges(this.chartsRowData ) : (this.isDistributed ? this.selectedColorScheme : [this.color])
     };
   }
@@ -3107,23 +3179,19 @@ xaxis: {
   }
   }
   legendsShowOrHide(){
+    if(this.legendSupportedChartTypes.has(this.chartType ?? '')){
+      this.applyApexLegendConfiguration();
+      return;
+    }
+
     if(this.chartOptions?.legend){
       this.chartOptions.legend.show = this.legendSwitch;
 
-    let object = { legend:  this.chartOptions.legend };
-    if (this.pieCharts) {
-      this.pieCharts.updateOptions(object);
+      const object = { legend:  this.chartOptions.legend };
+      if (this.treemapCharts) {
+        this.treemapCharts.updateOptions(object);
+      }
     }
-    else if (this.donutCharts) {
-      this.donutCharts.updateOptions(object);
-    }
-    else if (this.radialCharts) {
-      this.radialCharts.updateOptions(object);
-    }
-    else if (this.treemapCharts) {
-      this.treemapCharts.updateOptions(object);
-    }
-  }
   }
   dataLabelsShowOrHide(){
     if(this.chartOptions?.dataLabels){
@@ -3179,23 +3247,19 @@ xaxis: {
     }
   }
   legendPositionChange(){
+    if(this.legendSupportedChartTypes.has(this.chartType ?? '')){
+      this.applyApexLegendConfiguration();
+      return;
+    }
+
     if(this.chartOptions?.legend?.position){
       this.chartOptions.legend.position = this.legendsAllignment;
 
-    let object = { legend:  this.chartOptions.legend };
-    if (this.pieCharts) {
-      this.pieCharts.updateOptions(object);
+      const object = { legend:  this.chartOptions.legend };
+      if (this.treemapCharts) {
+        this.treemapCharts.updateOptions(object);
+      }
     }
-    else if (this.donutCharts) {
-      this.donutCharts.updateOptions(object);
-    }
-    else if (this.radialCharts) {
-      this.radialCharts.updateOptions(object);
-    }
-    else if (this.treemapCharts) {
-      this.treemapCharts.updateOptions(object);
-    }
-  }
   }
   donutSizeChange(){
     if (this.donutCharts) {

--- a/src/app/components/workbench/insight-echart/insight-echart.component.ts
+++ b/src/app/components/workbench/insight-echart/insight-echart.component.ts
@@ -188,6 +188,64 @@ export class InsightEchartComponent {
     }, 0);
   }
 
+  private readonly legendSupportedChartTypes = new Set([
+    'pie',
+    'donut',
+    'sidebyside',
+    'sidesidebar',
+    'stocked',
+    'stacked',
+    'hstocked',
+    'hstacked',
+    'hgrouped',
+    'multiline',
+    'barline'
+  ]);
+
+  private shouldUseLegendConfiguration(): boolean {
+    return this.legendSupportedChartTypes.has(this.chartType ?? '');
+  }
+
+  private getLegendConfiguration(): any {
+    const legendConfig: any = {
+      orient: this.legendOrient,
+      type: 'scroll',
+      show: this.legendSwitch
+    };
+
+    if (this.bottomLegend) {
+      legendConfig.bottom = this.bottomLegend;
+    }
+    if (this.leftLegend) {
+      legendConfig.left = this.leftLegend;
+    }
+    if (this.rightLegend) {
+      legendConfig.right = this.rightLegend;
+    }
+    if (this.topLegend) {
+      legendConfig.top = this.topLegend;
+    }
+
+    return legendConfig;
+  }
+
+  private applyLegendConfiguration(): void {
+    if (!this.shouldUseLegendConfiguration() || !this.chartOptions) {
+      return;
+    }
+
+    const legendConfig = this.getLegendConfiguration();
+    if (this.chartOptions.legend?.data) {
+      legendConfig.data = this.chartOptions.legend.data;
+    }
+
+    this.chartOptions.legend = legendConfig;
+
+    if (this.chartInstance) {
+      this.chartInstance.setOption({ legend: legendConfig });
+    }
+  }
+
  barChart(chartsColumnData? : any ,chartsRowData?: any ){
     if(chartsColumnData && chartsRowData){
       this.chartsColumnData = chartsColumnData;
@@ -326,10 +384,7 @@ horizontalBarChart(chartsColumnData?: any, chartsRowData?: any) {
   
   this.chartOptions = {
     backgroundColor: this.backgroundColor,
-    legend: {
-      orient: 'vertical',
-      left: 'left'
-    },
+    legend: this.getLegendConfiguration(),
     toolbox: {
       feature: {
         magicType: { show: true, type: ['line'] },
@@ -528,10 +583,7 @@ stackedChart(){
   this.chartOptions = {
     backgroundColor: this.backgroundColor,
     color:this.selectedColorScheme,
-    legend: {
-      orient: 'vertical',
-      left: 'left'
-    },
+    legend: this.getLegendConfiguration(),
     toolbox: {
       feature: {
         magicType: { show: true, type: ['line'] },
@@ -639,10 +691,7 @@ sidebySide(dualAxisColumnData? : any ,dualAxisRowData? : any ){
   this.chartOptions = {
     backgroundColor: this.backgroundColor,
     color:this.selectedColorScheme,
-    legend: {
-      orient: 'vertical',
-      left: 'left'
-    },
+    legend: this.getLegendConfiguration(),
     toolbox: {
       feature: {
         magicType: { show: true, type: ['line'] },
@@ -752,10 +801,7 @@ hgroupedChart(dualAxisColumnData? : any, dualAxisRowData? : any){
   this.chartOptions = {
     backgroundColor: this.backgroundColor,
     color:this.selectedColorScheme,
-    legend: {
-      orient: 'vertical',
-      left: 'left'
-    },
+    legend: this.getLegendConfiguration(),
     toolbox: {
       feature: {
         magicType: { show: true, type: ['line'] },
@@ -866,10 +912,7 @@ hgroupedChart(dualAxisColumnData? : any, dualAxisRowData? : any){
   this.chartOptions = {
     backgroundColor: this.backgroundColor,
     color:this.selectedColorScheme,
-    legend: {
-      orient: 'vertical',
-      left: 'left'
-    },
+    legend: this.getLegendConfiguration(),
     toolbox: {
       feature: {
         magicType: { show: true, type: ['line'] },
@@ -1197,15 +1240,7 @@ pieChart(chartsColumnData?:any[],chartsRowData?:any[]){
       trigger: 'item',
       formatter:(params:any) => params.name + ' : ' + this.formatNumber(params.value) 
     },
-    legend: {
-          bottom: this.bottomLegend, 
-          left: this.leftLegend, 
-          orient: this.legendOrient,
-          right:this.rightLegend,
-          top:this.topLegend,
-          type:'scroll',
-      show: this.legendSwitch 
-      },
+    legend: this.getLegendConfiguration(),
           label: {
       show : this.dataLabels,
       formatter: '{b}: {d}%',
@@ -1246,15 +1281,7 @@ donutChart(chartsColumnData?:any[],chartsRowData?:any[]){
     tooltip: {
       trigger: 'item',
     },
-    legend: {
-      bottom: this.bottomLegend, 
-          left: this.leftLegend, 
-          orient: this.legendOrient,
-          right:this.rightLegend,
-          top:this.topLegend,
-          type:'scroll',
-      show: this.legendSwitch // Control legend visibility
-  },            
+    legend: this.getLegendConfiguration(),
   label: {
       show : this.dataLabels,
       formatter: '{b}: {d}%',
@@ -1312,9 +1339,7 @@ barLineChart(){
         saveAsImage: { show: true }
       }
     },
-    legend: {
-      show:true
-    },
+    legend: this.getLegendConfiguration(),
     xAxis: [
       {
         type: 'category',
@@ -3491,14 +3516,11 @@ radarDistributionSetOptions() {
   }
   }
   legendSwitchSetOptions(){
-    if(this.chartType === 'donut' || this.chartType === 'pie' || this.chartType === 'radar'){
-      let obj ={
-        legend :{
-            show: this.legendSwitch
-        }
-      }
-      this.chartInstance?.setOption(obj);
+    if(this.shouldUseLegendConfiguration()){
+      this.applyLegendConfiguration();
+    } else if(this.chartType === 'radar' && this.chartOptions?.legend){
       this.chartOptions.legend.show = this.legendSwitch;
+      this.chartInstance?.setOption({ legend: this.chartOptions.legend });
     }
   }
   dataLabelsSetOptions(){
@@ -3724,62 +3746,10 @@ radarDistributionSetOptions() {
       this.chartOptions = { ...this.chartOptions, ...obj };
   }
   legendsAllignmentSetOptions(){
-    if(this.chartType === 'pie' || this.chartType === 'donut'){
-    if(this.legendsAllignment === 'top'){
-    let obj ={
-      legend :{
-        top: this.topLegend,
-        left: this.leftLegend,
-        orient: this.legendOrient,
-        bottom:'null',
-        right:'null',
-        show: this.legendSwitch 
-      },
+    if(this.shouldUseLegendConfiguration()){
+      this.applyLegendConfiguration();
     }
-    this.chartOptions.legend = obj;
-    this.chartInstance?.setOption(obj)
-  }
-  else if(this.legendsAllignment === 'bottom'){
-    let obj ={
-      legend :{
-          bottom: this.bottomLegend, 
-          left: this.leftLegend, 
-          orient: this.legendOrient,
-          // right:'null',
-          // top:'null',
-          show: this.legendSwitch,
-
-      },
-    }
-    this.chartOptions.legend = obj;
-    this.chartInstance?.setOption(obj)
-  }
-  else if(this.legendsAllignment === 'left'){
-    let obj ={
-      legend :{
-          left: this.leftLegend, 
-          top: this.topLegend, 
-          orient: this.legendOrient,
-          show: this.legendSwitch 
-      },
-    }
-    this.chartOptions.legend = obj;
-    this.chartInstance?.setOption(obj)
-  }
-  else if(this.legendsAllignment === 'right'){
-    let obj ={
-      legend :{
-         right: this.rightLegend, 
-         top:this.topLegend, 
-         orient:this.legendOrient,
-         show: this.legendSwitch 
-      },
-    }
-    this.chartOptions.legend = obj;
-    this.chartInstance?.setOption(obj)
-  }
-  }
-  else if(this.chartType === 'radar'){
+    else if(this.chartType === 'radar'){
     let legendPosition: any = {};
 
     if (this.legendsAllignment === 'top') {

--- a/src/app/components/workbench/sheets/sheets.component.html
+++ b/src/app/components/workbench/sheets/sheets.component.html
@@ -5215,7 +5215,7 @@
                                                         </div>
                                                     </div>
                                                 </div>
-                                                    <div *ngIf="((pie && chartId) || donut || radar || radial)">
+                                                    <div *ngIf="((pie && chartId) || donut || radar || radial || sidebyside || stocked || horizentalStocked || grouped || multiLine || barLine)">
                                                         <div class="d-flex align-items-center justify-content-between mb-2 flex-wrap gap-2 p-2 border rounded-2">
                                                             <div class=""> 
                                                                 <label class="mb-0">Legends </label>


### PR DESCRIPTION
## Summary
- add reusable legend configuration helpers to ECharts dual-axis chart types and update runtime alignment/toggle handlers
- extend ApexCharts dual-axis charts to respect the legend toggle/orientation inputs via centralized helpers
- surface legend visibility and alignment controls in the Sheets UI for supported dual-axis visualizations

## Testing
- npm run build *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ee19551cac8320b1d1a83050f2321f