### PR TITLE
Refactor SDK sheet loading to reuse sheet component logic

### DIFF
--- a/src/app/components/workbench/sheet-sdk/sheet-sdk.component.html
+++ b/src/app/components/workbench/sheet-sdk/sheet-sdk.component.html
@@ -1,56 +1,18 @@
-@if(chartType){
 <div class="sheet-sdk-container">
-  <ng-container>
-    @if(chartType =='kpi' || chartType =='pivotTable' || chartType =='table'){
-    <app-sheets [sdkSheetId]="sheetId" [sdkQuerySetID]="sdkQuerySetID" [sdkDatabaseID]="sdkDatabaseID"></app-sheets>
-    <!-- Table rendering for non-chart sheets -->
-    <!-- <app-custom-sheets
-          *ngIf="!isApexChart"
-          [table]="true"
-          [chartId]="chartType"
-          [tableColumnsDisplay]="tableColumnsDisplay"
-          [tableDataDisplay]="tableDataDisplay"
-          [itemsPerPage]="itemsPerPage"
-          [page]="page"
-          [totalItems]="totalItems"
-          [bandingSwitch]="bandingSwitch"
-          [color1]="color1"
-          [color2]="color2"
-          [headerFontFamily]="headerFontFamily"
-          [headerFontStyle]="headerFontStyle"
-          [headerFontDecoration]="headerFontDecoration"
-          [headerFontColor]="headerFontColor"
-          [headerFontAlignment]="headerFontAlignment"
-          [headerFontWeight]="headerFontWeight"
-          [headerFontSize]="headerFontSize"
-          [tableDataFontFamily]="tableDataFontFamily"
-          [tableDataFontWeight]="tableDataFontWeight"
-          [tableDataFontStyle]="tableDataFontStyle"
-          [tableDataFontDecoration]="tableDataFontDecoration"
-          [tableDataFontColor]="tableDataFontColor"
-          [tableDataFontAlignment]="tableDataFontAlignment"
-          [tableDataFontSize]="tableDataFontSize"
-          [decimalPlaces]="decimalPlaces"
-          [prefix]="prefix"
-          [suffix]="suffix"
-          [displayUnits]="displayUnits"
-          (pageChange)="pageChangeTable($event)">
-        </app-custom-sheets> -->
-
-    } @else {
-
-    @if(isApexChart){
-
-    <app-insight-apex [SDKChartOptions]="chartOptions" [chartType]="chartType">
-    </app-insight-apex>
-
-    } @else {
-
-    <app-insight-echart [chartType]="chartType" [SDKChartOptions]="chartOptions">
-    </app-insight-echart>
-
-    }
-    }
-  </ng-container>
+  @if (loading) {
+    <div class="d-flex justify-content-center align-items-center h-100 w-100">
+      <span>Loading...</span>
+    </div>
+  } @else if (error) {
+    <div class="d-flex justify-content-center align-items-center h-100 w-100 text-danger">
+      <span>{{ error }}</span>
+    </div>
+  } @else if (sdkPayload) {
+    <app-sheets
+      [sdkSheetId]="sheetId"
+      [sdkQuerySetID]="sdkQuerySetID"
+      [sdkDatabaseID]="sdkDatabaseID"
+      [sdkPreloaded]="sdkPayload"
+    ></app-sheets>
+  }
 </div>
-}

--- a/src/app/components/workbench/sheet-sdk/sheet-sdk.component.ts
+++ b/src/app/components/workbench/sheet-sdk/sheet-sdk.component.ts
@@ -1,236 +1,99 @@
 import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { InsightApexComponent } from '../insight-apex/insight-apex.component';
-import { InsightEchartComponent } from '../insight-echart/insight-echart.component';
-import { WorkbenchService } from '../workbench.service';
-import { CustomSheetsComponent } from '../custom-sheets/custom-sheets.component';
 import { SheetsComponent } from '../sheets/sheets.component';
-import { SheetDataTransformerService } from '../../../services/sheet-data-transformer.service';
-import { ChartRenderService } from '../../../services/chart-render.service';
+import { WorkbenchService } from '../workbench.service';
+
+interface SheetSdkPayload {
+  sheet_retrieve_data: any;
+  sheet_filter_data?: any;
+}
 
 @Component({
   selector: 'app-sheet-sdk',
   standalone: true,
-  imports: [CommonModule, InsightApexComponent, InsightEchartComponent, CustomSheetsComponent,SheetsComponent],
+  imports: [CommonModule, SheetsComponent],
   templateUrl: './sheet-sdk.component.html',
   styleUrl: './sheet-sdk.component.scss'
 })
 export class SheetSdkComponent {
-  sheetId! : number;                                                                                                       
-      chartType! : string;                                                                                                     
-      config: any;                                                                                                        
-      data: any;                                                                                                          
-      loading = true;                                                                                                     
-      error: string | null = null;                                                                                        
+  sheetId!: number;
+  loading = true;
+  error: string | null = null;
   clientId!: string;
-  sheetToken!: string      
-  isApexChart : boolean = false;                                                                                                      
-  chartOptions: any;
-  embedFilters: any;
-  // Table display properties
-  tableColumnsDisplay: string[] = [];
-  tableDataDisplay: any[] = [];
-  itemsPerPage = 10;
-  page = 1;
-  totalItems = 0;
-  bandingSwitch = false;
-  color1 = '#ffffff';
-  color2 = '#f3f3f3';
-  headerFontFamily = '';
-  headerFontStyle = '';
-  headerFontDecoration = '';
-  headerFontColor = '';
-  headerFontAlignment: 'left' | 'center' | 'right' = 'left';
-  headerFontWeight = '';
-  headerFontSize = '';
-  tableDataFontFamily = '';
-  tableDataFontWeight = '';
-  tableDataFontStyle = '';
-  tableDataFontDecoration = '';
-  tableDataFontColor = '';
-  tableDataFontAlignment: 'left' | 'center' | 'right' = 'left';
-  tableDataFontSize = '';
-  decimalPlaces = 2;
-  prefix = '';
-  suffix = '';
-  displayUnits = '';
+  sheetToken!: string;
   sdkQuerySetID!: number;
   sdkDatabaseID!: number;
+  embedFilters: any;
+  sdkPayload: SheetSdkPayload | null = null;
 
-    xAxisCategories: string[] = [];
-  multiSeriesChartData: { name: string; data: number[] }[] = [];
-  combinedTableData: any[] = [];
-  columnNames: string[] = [];
-      constructor(                                                                                                        
-        private route: ActivatedRoute,                                                                                    
-        private workbenchService: WorkbenchService,
-         private transformer: SheetDataTransformerService  ,
-         private chartRenderService: ChartRenderService                                                                           
-      ) {}                                                                                                                
-                                                                                                                          
-    ngOnInit(): void {                                                                                                 
+  constructor(
+    private route: ActivatedRoute,
+    private workbenchService: WorkbenchService
+  ) {}
 
-        this.sheetToken = this.route.snapshot.params['sheetToken'];
-        this.clientId = this.route.snapshot.params['clientId'];
-        this.route.queryParams.subscribe(params => {
-          const rawFilters = params['filters'];
-          if (rawFilters) {
-            try {
-              this.embedFilters = JSON.parse(rawFilters);
-              console.log('Filters object:', this.embedFilters);
-              // Expected output: { name: ['US', 'UK'], idList: [3, 4] }
-            } catch (e) {
-              console.error('Error parsing filters:', e);
-            }
-          }
-        });
-        let accessToken = this.route.snapshot.params['token'];
-        const userToken = { Token: accessToken,};
-        localStorage.setItem('currentUser', JSON.stringify(userToken));                                                         
-          if (this.sheetToken) {   
-            let sheetPayload = {sheet_token : this.sheetToken}
-            this.workbenchService.fetchSheetId(sheetPayload).subscribe({                                                         
-              next: (data:any) => {                                                                                                  
-                this.sheetId = data.dashboard_id;     
-                this.sdkQuerySetID = data.queryset_id;
-                this.sdkDatabaseID = data.server_id;
-                this.fetchData(1);                                                   
-              },                                                                                                              
-              error: (err : any) => {                                                                                                 
-                console.error(err);                                                                                           
-                this.error = 'Failed to load chart data';                                                                     
-                this.loading = false;                                                                                         
-              }                                                                                                               
-            });                                                                                                                                                                                                                                                                                             
-          } else {                                                                                                        
-            this.error = 'Sheet Token is required';                                                                          
-            this.loading = false;                                                                                         
-          }                                                                                                                                                                                                                           
-      }  
-      
-      setChartType(chartId: number){
-        const cfg = this.chartRenderService.getChartConfig(chartId);
-        if(cfg){
-          this.chartType = cfg.chartType;
+  ngOnInit(): void {
+    this.sheetToken = this.route.snapshot.params['sheetToken'];
+    this.clientId = this.route.snapshot.params['clientId'];
+    this.route.queryParams.subscribe(params => {
+      const rawFilters = params['filters'];
+      if (rawFilters) {
+        try {
+          this.embedFilters = JSON.parse(rawFilters);
+          console.log('Filters object:', this.embedFilters);
+        } catch (e) {
+          console.error('Error parsing filters:', e);
         }
       }
-  // fetchDataProxy(){
-  //       this.loading = true;
-  //   let filterKeys;
-  //   let filterValues;
-  //   let payload;
-  //   if (this.embedFilters) {
-  //     filterKeys = Object.keys(this.embedFilters);
-  //     filterValues = Object.values(this.embedFilters);
-  //     payload = {
-  //       "filter_name": filterKeys,
-  //       "sheet_id": this.sheetId,
-  //       "input_list": filterValues
-  //     }
-  //   } else {
-  //      payload = { "sheet_id": this.sheetId };
-  //   }
-  //   this.workbenchService.getSheetSdkData(payload).subscribe({
-  //     next: (data: any) => {
-  //     if(data){
-  //       this.fetchData();
-  //     }
-  //     },
-  //      error: (err: any) => {
-  //       console.error(err);
-  //       this.error = 'Failed to load chart data';
-  //       this.loading = false;
-  //     }
-  //   })
-  // }                                                                                                                        
-  fetchData(attempt: number): void {
-    this.loading = true;
-    let filterKeys;
-    let filterValues;
-    let payload;
-    if (this.embedFilters) {
-      filterKeys = Object.keys(this.embedFilters);
-      filterValues = Object.values(this.embedFilters);
-      payload = {
-        "filter_name": filterKeys,
-        "sheet_id": this.sheetId,
-        "input_list": filterValues
-      }
+    });
+    const accessToken = this.route.snapshot.params['token'];
+    const userToken = { Token: accessToken };
+    localStorage.setItem('currentUser', JSON.stringify(userToken));
+    if (this.sheetToken) {
+      const sheetPayload = { sheet_token: this.sheetToken };
+      this.workbenchService.fetchSheetId(sheetPayload).subscribe({
+        next: (data: any) => {
+          this.sheetId = data.dashboard_id;
+          this.sdkQuerySetID = data.queryset_id;
+          this.sdkDatabaseID = data.server_id;
+          this.fetchData(1);
+        },
+        error: (err: any) => {
+          console.error(err);
+          this.error = 'Failed to load chart data';
+          this.loading = false;
+        }
+      });
     } else {
-       payload = { "sheet_id": this.sheetId };
+      this.error = 'Sheet Token is required';
+      this.loading = false;
+    }
+  }
+
+  private fetchData(attempt: number): void {
+    this.loading = true;
+    let payload: any;
+    if (this.embedFilters) {
+      const filterKeys = Object.keys(this.embedFilters);
+      const filterValues = Object.values(this.embedFilters);
+      payload = {
+        filter_name: filterKeys,
+        sheet_id: this.sheetId,
+        input_list: filterValues
+      };
+    } else {
+      payload = { sheet_id: this.sheetId };
     }
     this.workbenchService.getSheetSdkData(payload).subscribe({
-      next: (data: any) => {
+      next: (data: SheetSdkPayload | '<Response [404]>' | null) => {
         console.log(data);
-        if(data === '<Response [404]>' && attempt <= 2){
+        if (data === '<Response [404]>' && attempt <= 2) {
           this.fetchData(attempt + 1);
+        } else if (data && data !== '<Response [404]>') {
+          this.sdkPayload = data as SheetSdkPayload;
+          this.loading = false;
         } else {
-          const sheet = data.sheet_retrieve_data.sheet_data;
-          this.isApexChart = sheet.isApexChart;
-          this.setChartType(data.sheet_retrieve_data.chart_id);
-          this.chartOptions = sheet.savedChartOptions;
-          // If it's not a chart, render table via CustomSheetsComponent
-          if (data.sheet_filter_data?.data) {
-            const dataToChange = data.sheet_filter_data?.data
-            const {
-              xAxisCategories,
-              multiSeriesChartData,
-              combinedTableData,
-              columnNames
-            } = this.transformer.transformTableAndChartData(dataToChange);
-
-            this.xAxisCategories = xAxisCategories;
-            this.multiSeriesChartData = multiSeriesChartData;
-            this.combinedTableData = combinedTableData;
-            this.columnNames = columnNames;
-
-            this.chartOptions = this.transformer.updateChartOptions(
-              this.chartOptions,
-              this.chartType,
-              this.isApexChart,
-              this.xAxisCategories,
-              this.multiSeriesChartData
-            );
-          }
-
-          if (!this.isApexChart) {
-            // columns and rows arrays from API
-            const cols: string[] = sheet.columns || sheet.table?.columns || [];
-            const rows: any[][] = sheet.rows || sheet.table?.rows || [];
-            this.tableColumnsDisplay = cols;
-            // Map row arrays to objects
-            this.tableDataDisplay = rows.map(r => {
-              const obj: any = {};
-              cols.forEach((c, i) => obj[c] = r[i]);
-              return obj;
-            });
-            this.totalItems = this.tableDataDisplay.length;
-            this.itemsPerPage = sheet.itemsPerPage ?? this.itemsPerPage;
-            this.page = 1;
-            this.bandingSwitch = sheet.bandingSwitch ?? this.bandingSwitch;
-            this.color1 = sheet.color1 ?? this.color1;
-            this.color2 = sheet.color2 ?? this.color2;
-            this.headerFontFamily = sheet.headerFontFamily ?? this.headerFontFamily;
-            this.headerFontStyle = sheet.headerFontStyle ?? this.headerFontStyle;
-            this.headerFontDecoration = sheet.headerFontDecoration ?? this.headerFontDecoration;
-            this.headerFontColor = sheet.headerFontColor ?? this.headerFontColor;
-            this.headerFontAlignment = sheet.headerFontAlignment ?? this.headerFontAlignment;
-            this.headerFontWeight = sheet.headerFontWeight ?? this.headerFontWeight;
-            this.headerFontSize = sheet.headerFontSize ?? this.headerFontSize;
-            this.tableDataFontFamily = sheet.tableDataFontFamily ?? this.tableDataFontFamily;
-            this.tableDataFontWeight = sheet.tableDataFontWeight ?? this.tableDataFontWeight;
-            this.tableDataFontStyle = sheet.tableDataFontStyle ?? this.tableDataFontStyle;
-            this.tableDataFontDecoration = sheet.tableDataFontDecoration ?? this.tableDataFontDecoration;
-            this.tableDataFontColor = sheet.tableDataFontColor ?? this.tableDataFontColor;
-            this.tableDataFontAlignment = sheet.tableDataFontAlignment ?? this.tableDataFontAlignment;
-            this.tableDataFontSize = sheet.tableDataFontSize ?? this.tableDataFontSize;
-            this.decimalPlaces = sheet.decimalPlaces ?? this.decimalPlaces;
-            this.prefix = sheet.prefix ?? this.prefix;
-            this.suffix = sheet.suffix ?? this.suffix;
-            this.displayUnits = sheet.displayUnits ?? this.displayUnits;
-          }
-          // done loading
+          this.error = 'Failed to load chart data';
           this.loading = false;
         }
       },
@@ -240,89 +103,5 @@ export class SheetSdkComponent {
         this.loading = false;
       }
     });
-  }       
-  /**
-   * Handle pagination change from CustomSheetsComponent
-   */
-  pageChangeTable(newPage: number) {
-    this.page = newPage;
   }
-
-
-//   private buildTableAndChartData(data: any): void {
-//   const colArray = data?.col || [];
-//   const rowArray = data?.row || [];
-
-//   this.xAxisCategories = [];
-//   this.multiSeriesChartData = [];
-//   this.combinedTableData = [];
-//   this.columnNames = [];
-
-//   // Combine column and row names for table headers
-//   this.columnNames = [
-//     ...colArray.map((col: { column: any; }) => col.column),
-//     ...rowArray.map((row: { col: any; }) => row.col)
-//   ];
-
-//   // Determine row count from the first column or row
-//   const rowCount = Math.max(
-//     colArray[0]?.result_data?.length || 0,
-//     rowArray[0]?.result_data?.length || 0
-//   );
-
-//   // Combine data row-wise
-//   for (let i = 0; i < rowCount; i++) {
-//     const rowObj: any = {};
-
-//     colArray.forEach((col: { column: string | number; result_data: any[]; }) => {
-//       rowObj[col.column] = col.result_data?.[i];
-//     });
-
-//     rowArray.forEach((row: { col: string | number; result_data: any[]; }) => {
-//       rowObj[row.col] = row.result_data?.[i];
-//     });
-
-//     this.combinedTableData.push(rowObj);
-//   }
-
-//   // Use first column's result_data for xAxis categories
-//   this.xAxisCategories = colArray[0]?.result_data?.map((v: any) => v ?? 'null') || [];
-
-//   // Build chart series
-//   this.multiSeriesChartData = rowArray.map((row: { col: any; result_data: any; }) => ({
-//     name: row.col,
-//     data: row.result_data || []
-//   }));
-
-//   console.log(this.xAxisCategories);
-//   console.log(this.multiSeriesChartData);
-
-//   // this.cdr.detectChanges();
-// }
-
-
-//   private injectMultiSeriesChartOptions(): void {
-//   if (!this.chartOptions) this.chartOptions = {};
-   
-//   if(this.isApexChart){
-//     if(['pie', 'donut', 'guage'].includes(this.chartType)){
-//       this.chartOptions.series = this.multiSeriesChartData[0].data;
-//       this.chartOptions.labels = this.xAxisCategories;
-//     } else {
-//       this.chartOptions.series.forEach((row: any, index: any) => {
-//         row.data = this.multiSeriesChartData[index].data
-//       });
-//       this.chartOptions.xaxis.categories = this.xAxisCategories;
-//     }
-//   } else {
-//     this.chartOptions.series.forEach((row: any, index: any) => {
-//       row.data = this.multiSeriesChartData[index].data
-//     });
-//     this.chartOptions.xAxis.data = this.xAxisCategories;
-//   }
-//   // Trigger chart update
-//   this.chartOptions = { ...this.chartOptions };
-// }
-
-
 }

--- a/src/app/components/workbench/sheets/sheets.component.ts
+++ b/src/app/components/workbench/sheets/sheets.component.ts
@@ -1,4 +1,4 @@
-import { Component,ViewChild,NgZone, ChangeDetectionStrategy, ChangeDetectorRef, ElementRef,Input, HostListener, AfterViewInit, ViewEncapsulation, SecurityContext } from '@angular/core';
+import { Component,ViewChild,NgZone, ChangeDetectionStrategy, ChangeDetectorRef, ElementRef,Input, HostListener, AfterViewInit, ViewEncapsulation, SecurityContext, OnChanges, SimpleChanges } from '@angular/core';
 import { NgbDropdown, NgbModal, NgbModule, NgbTooltipModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgSelectModule } from '@ng-select/ng-select';
 import { SharedModule } from '../../../shared/sharedmodule';
@@ -83,6 +83,11 @@ interface RangeSliderModel {
   maxValue: number;
   options: Options;
 }
+
+interface SheetSdkPreloadedPayload {
+  sheet_retrieve_data: any;
+  sheet_filter_data?: any;
+}
 declare global {
   interface JQuery {
     sortable(): JQuery;
@@ -113,7 +118,7 @@ declare var $:any;
   templateUrl: './sheets.component.html',
   styleUrl: './sheets.component.scss'
 })
-export class SheetsComponent{
+export class SheetsComponent implements OnChanges{
   tableColumnsData = [] as any;
   draggedtables = [] as any;
   draggedColumns = [] as any;
@@ -170,6 +175,8 @@ export class SheetsComponent{
   @Input() sdkSheetId! : number;
   @Input() sdkQuerySetID! : number;
   @Input() sdkDatabaseID! : number;
+  @Input() sdkPreloaded?: SheetSdkPreloadedPayload;
+  private sdkInitialized = false;
 
  /* private data = [
     {"Framework": "Vue", "Stars": "166443", "Released": "2014"},
@@ -599,7 +606,19 @@ isSidebarCollapsed: boolean = false;
   ngAfterViewInit(): void {
 
   }
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['sdkPreloaded']?.currentValue) {
+      this.initializeFromSdk(changes['sdkPreloaded'].currentValue as SheetSdkPreloadedPayload);
+    }
+  }
   ngOnInit(): void {
+    if (this.sdkInitialized && this.sdkPreloaded) {
+      return;
+    }
+    if (this.sdkPreloaded) {
+      this.initializeFromSdk(this.sdkPreloaded);
+      return;
+    }
     if(this.sdkSheetId){
       this.retriveDataSheet_id = this.sdkSheetId;
       this.qrySetId = this.sdkQuerySetID;
@@ -640,6 +659,29 @@ isSidebarCollapsed: boolean = false;
     }
     console.log(this.defaultColorSchemes);
   }
+  }
+  private initializeFromSdk(preloaded: SheetSdkPreloadedPayload): void {
+    if (!preloaded?.sheet_retrieve_data) {
+      return;
+    }
+    this.isEmbedSDK = true;
+    const shouldInitializeSheet = !this.sdkInitialized;
+    this.sdkInitialized = true;
+    const retrieve = preloaded.sheet_retrieve_data;
+    this.retriveDataSheet_id = retrieve?.sheet_id ?? this.sdkSheetId ?? this.retriveDataSheet_id;
+    if (retrieve?.sheet_id && !this.sdkSheetId) {
+      this.sdkSheetId = retrieve.sheet_id;
+    }
+    this.qrySetId = this.sdkQuerySetID ?? retrieve?.queryset_id ?? this.qrySetId;
+    this.databaseId = this.sdkDatabaseID ?? retrieve?.hierarchy_id ?? this.databaseId;
+    if (shouldInitializeSheet) {
+      this.setSheetData(retrieve, false, undefined, false);
+    }
+    if (preloaded.sheet_filter_data) {
+      this.resetDataExtractionState();
+      this.handleDataExtractionResponse(preloaded.sheet_filter_data, false);
+      this.hasUnSavedChanges = false;
+    }
   }
   isColorSchemeDropdownOpen = false;
   toggleDropdownColorScheme() {
@@ -791,7 +833,7 @@ try {
       
 
 
-      dataExtraction(isSyncData : boolean){
+      private resetDataExtractionState(): void {
         this.dualAxisColumnData = [];
         this.tablePreviewColumn = [];
         this.tablePreviewRow = [];
@@ -804,6 +846,117 @@ try {
         this.dualAxisRowData = [];
         this.radarRowData = [];
         this.sortedData = [];
+      }
+
+      private handleDataExtractionResponse(responce: any, isSyncData: boolean): void {
+        this.tablePaginationRows=responce.rows;
+        this.tablePaginationColumn=responce.columns;
+        this.tablePaginationCustomQuery=responce.custom_query;
+        this.chartsDataSet(responce);
+        this.mulColData = responce.columns;
+        this.mulRowData = responce.rows;
+        this.pivotMeasureValues = responce.pivot_measure;
+        this.pivotColumnData = responce?.data?.col;
+        this.pivotRowData = responce?.data?.row;
+        this.pivotMeasureData = responce?.data?.pivot_measure;
+        if(isSyncData){
+        }
+        if (this.chartsRowData.length > 0) {
+          // this.enableDisableCharts();
+          // this.chartsOptionsSet();
+          if (this.retriveDataSheet_id && !this.isEChatrts) {
+            const dimensions: Dimension[] = this.dualAxisColumnData;
+            // const categories = this.flattenDimensions(dimensions);
+            // this.updateChart();
+          }
+          else{
+            // this.chartsOptionsSet();
+          }
+        }
+        this.chartsOptionsSet();
+        this.getDimensionAndMeasures();
+        this.changeSelectedColumn();
+        if (((this.kpi || this.guage) && (this.draggedColumns.length > 0 || this.draggedRows.length !== 1)) || (!(this.kpi || this.guage || this.pivotTable) &&(this.draggedColumns.length < 1 || this.draggedRows.length < 1)) || (this.map && (this.draggedRows.length < 1 || this.draggedColumns.length != 1)) || (this.barLine && this.draggedRows.length !== 2) || (this.calendar && this.draggedColumnsData[0]?.[2] !== '')) {
+          if(!this.table){
+            this.toasterService.info('Changed to Table Chart','Info',{ positionClass: 'toast-top-right'});
+          }
+          this.table = true;
+          this.pivotTable = false;
+          this.bar = false;
+          this.horizontalBar = false;
+          this.area = false;
+          this.line = false;
+          this.pie = false;
+          this.scatter = false;
+          this.sidebyside = false;
+          this.stocked = false;
+          this.barLine = false;
+          this.horizentalStocked = false;
+          this.grouped = false;
+          this.multiLine = false;
+          this.donut = false;
+          this.chartId = 1;
+          this.radar = false;
+          this.kpi = false;
+          this.heatMap = false;
+          this.guage = false;
+          this.funnel = false;
+          this.calendar = false;
+          this.map=false;
+          this.treemap = false;
+          this.radial = false;
+          // this.tableDisplayPagination();
+        } else if(((this.pie || this.bar || this.scatter || this.horizontalBar || this.area || this.line || this.donut || this.funnel || this.calendar || this.radial || this.treemap) && (this.draggedColumns.length > 1 || this.draggedRows.length > 1))) {
+          this.table = false;
+          this.pivotTable = false;
+          this.bar = false;
+          this.horizontalBar = false;
+          this.area = false;
+          this.line = false;
+          this.pie = false;
+          this.scatter = false;
+          this.sidebyside = true;
+          this.stocked = false;
+          this.barLine = false;
+          this.horizentalStocked = false;
+          this.grouped = false;
+          this.multiLine = false;
+          this.donut = false;
+          this.chartId = 7;
+          this.radar = false;
+          this.kpi = false;
+          this.heatMap = false;
+          this.funnel = false;
+          this.guage = false;
+          this.calendar = false;
+          this.map = false;
+          this.treemap = false;
+          this.radial = false;
+          // this.sidebysideBar();
+          this.resetCustomizations();
+          this.chartType = 'sidebyside';
+          this.toasterService.info('Changed to Dual Axis Chart','Info',{ positionClass: 'toast-top-right'});
+          this.chartType = 'sidebyside'
+        }
+        if(this.pivotTable){
+          this.pivotTableDatatransform(isSyncData, true);
+        }
+        if(this.table){
+          this.page = 1;
+          this.pageNo = 1;
+          this.tableDisplayPagination(isSyncData);
+        }
+        if(isSyncData && !this.table && !this.pivotTable){
+          if(this.kpi){
+            this.sheetSave();
+          } else{
+            this.isSheetSaveOrUpdate = true;
+          }
+        }
+      }
+
+      dataExtraction(isSyncData : boolean){
+        this.resetDataExtractionState();
         let draggedColumnsObj;
         if (this.dateDrillDownSwitch && this.draggedColumnsData && this.draggedColumnsData.length > 0) {
           draggedColumnsObj = _.cloneDeep(this.draggedColumnsData);
@@ -844,110 +997,7 @@ try {
         }
         this.workbechService.getDataExtraction(obj).subscribe({
           next: (responce: any) => {
-            this.tablePaginationRows=responce.rows;
-            this.tablePaginationColumn=responce.columns;
-            this.tablePaginationCustomQuery=responce.custom_query;
-            this.chartsDataSet(responce);
-            this.mulColData = responce.columns;
-            this.mulRowData = responce.rows;
-            this.pivotMeasureValues = responce.pivot_measure;
-            this.pivotColumnData = responce?.data?.col;
-            this.pivotRowData = responce?.data?.row;
-            this.pivotMeasureData = responce?.data?.pivot_measure;
-            if(isSyncData){
-            }
-            if (this.chartsRowData.length > 0) {
-              // this.enableDisableCharts();
-              // this.chartsOptionsSet();
-              if (this.retriveDataSheet_id && !this.isEChatrts) {
-                const dimensions: Dimension[] = this.dualAxisColumnData;
-                // const categories = this.flattenDimensions(dimensions);
-                // this.updateChart();
-              }
-              else{
-                // this.chartsOptionsSet();
-              }
-            }
-            this.chartsOptionsSet();
-            this.getDimensionAndMeasures();
-            this.changeSelectedColumn();
-            if (((this.kpi || this.guage) && (this.draggedColumns.length > 0 || this.draggedRows.length !== 1)) || (!(this.kpi || this.guage || this.pivotTable) &&(this.draggedColumns.length < 1 || this.draggedRows.length < 1)) || (this.map && (this.draggedRows.length < 1 || this.draggedColumns.length != 1)) || (this.barLine && this.draggedRows.length !== 2) || (this.calendar && this.draggedColumnsData[0]?.[2] !== '')) {
-              if(!this.table){
-                this.toasterService.info('Changed to Table Chart','Info',{ positionClass: 'toast-top-right'});
-              }
-              this.table = true;
-              this.pivotTable = false;
-              this.bar = false;
-              this.horizontalBar = false;
-              this.area = false;
-              this.line = false;
-              this.pie = false;
-              this.scatter = false;
-              this.sidebyside = false;
-              this.stocked = false;
-              this.barLine = false;
-              this.horizentalStocked = false;
-              this.grouped = false;
-              this.multiLine = false;
-              this.donut = false;
-              this.chartId = 1;
-              this.radar = false;
-              this.kpi = false;
-              this.heatMap = false;
-              this.guage = false;
-              this.funnel = false;
-              this.calendar = false;
-              this.map=false;
-              this.treemap = false;
-              this.radial = false;
-              // this.tableDisplayPagination();
-            } else if(((this.pie || this.bar || this.scatter || this.horizontalBar || this.area || this.line || this.donut || this.funnel || this.calendar || this.radial || this.treemap) && (this.draggedColumns.length > 1 || this.draggedRows.length > 1))) {
-              this.table = false;
-              this.pivotTable = false;
-              this.bar = false;
-              this.horizontalBar = false;
-              this.area = false;
-              this.line = false;
-              this.pie = false;
-              this.scatter = false;
-              this.sidebyside = true;
-              this.stocked = false;
-              this.barLine = false;
-              this.horizentalStocked = false;
-              this.grouped = false;
-              this.multiLine = false;
-              this.donut = false;
-              this.chartId = 7;
-              this.radar = false;
-              this.kpi = false;
-              this.heatMap = false;
-              this.funnel = false;
-              this.guage = false;
-              this.calendar = false;
-              this.map = false;
-              this.treemap = false;
-              this.radial = false;
-              // this.sidebysideBar();
-              this.resetCustomizations();
-              this.chartType = 'sidebyside';
-              this.toasterService.info('Changed to Dual Axis Chart','Info',{ positionClass: 'toast-top-right'});
-              this.chartType = 'sidebyside'
-            }
-            if(this.pivotTable){
-              this.pivotTableDatatransform(isSyncData, true);
-            }
-            if(this.table){
-              this.page = 1;
-              this.pageNo = 1;
-              this.tableDisplayPagination(isSyncData);
-            }
-            if(isSyncData && !this.table && !this.pivotTable){
-              if(this.kpi){
-                this.sheetSave();
-              } else{
-                this.isSheetSaveOrUpdate = true;
-              }
-            }
+            this.handleDataExtractionResponse(responce, isSyncData);
           },
           error: (error) => {
             console.log(error);


### PR DESCRIPTION
## Summary
- route SDK sheet payloads through `SheetsComponent` via a new `sdkPreloaded` input so preloaded retrieval data skips redundant API calls
- reuse the existing data extraction state handlers when SDK filter data is provided to preserve drilldown and interaction behaviour
- simplify `SheetSdkComponent` to delegate rendering and state management to `SheetsComponent`, maintaining consistent loading and error UX

## Testing
- npm run lint *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68fb1a9bc6b8832083e186c75dc533c4